### PR TITLE
Enable adaptive threats and learned emitter coordination

### DIFF
--- a/ImmuneCogGraph.py
+++ b/ImmuneCogGraph.py
@@ -12,6 +12,11 @@ from memory_net_unit import MemoryNetUnit
 from processor_immune import ImmuneProcessor
 from special_emitter import SpecialEmitter
 from emitter_actions import ACTION_BLOCK, ACTION_QUARANTINE, ACTION_HACK_DEFENSE
+from adaptive_guidance import (
+    AdaptiveGuidanceModule,
+    ASSIGNMENT_LEARNED,
+    ASSIGNMENT_SELF,
+)
 from config_runtime import RF
 from typing import List
 import random
@@ -36,8 +41,7 @@ FLASH_ATTN_AVAILABLE = False
 MIN_PATROL_DIST = 3      # 巡逻目标与当前位置的最小曼哈顿距离
 HIT_BONUS       = 1.0     # 命中立刻奖励
 MISS_PENALTY    = 0.00    # 打空扣分
-GUIDED_FACTOR   = 0.3      # guided 奖励折扣
-MAX_GUIDED_DIST = 5
+LEARNED_FACTOR  = 0.3     # learned assignment reward bias
 
 class ImmuneCogGraph(CogGraph):
     """
@@ -57,7 +61,7 @@ class ImmuneCogGraph(CogGraph):
         if env is None:
             env = GridSecurityEnv(size=10, device=device)
         self.last_flat_idx = 0
-        # 混合策略控制：guided 的比例，逐步衰减到 0
+        # 自适应调度模块：通过学习选择目标而非硬编码指导
         super().__init__(rl_agent, device=device, env=env)
 
         # --- 1) 定义 hack channels 数量 & 总输入通道数 ---
@@ -123,8 +127,9 @@ class ImmuneCogGraph(CogGraph):
             self.env.infected_map, dtype=torch.float16, device=self.device
         )
         self._update_target_vector()
+        self.adaptive_guidance = AdaptiveGuidanceModule(self.env.size, device=self.device)
         self.last_report_stage = None
-        self.hack_kill_stats = {"self_direct": 0, "guided": 0}
+        self.hack_kill_stats = {ASSIGNMENT_SELF: 0, ASSIGNMENT_LEARNED: 0}
         # —— 新增：连续无感染计数器 —— #
         self.zero_infection_counter = 0
         # 追踪各黑客类型的击杀数
@@ -145,9 +150,7 @@ class ImmuneCogGraph(CogGraph):
         self.prev_priv = torch.zeros_like(self.env.privilege_level)
         self.prev_vuln = torch.zeros_like(self.env.vulnerability)
         self.prev_fail = torch.zeros_like(self.env.login_failures)
-        self.kill_stats = {"self_direct": 0, "guided": 0, "last_reset": 0}
-        self.guided_prob = 0.4
-        self.guided_decay = 0.0001  # 每 step 衰减量，可按需调整
+        self.kill_stats = {ASSIGNMENT_SELF: 0, ASSIGNMENT_LEARNED: 0, "last_reset": 0}
         seq_len = self.env.size * self.env.size
 
         # ─────────── 静息模式相关字段 ─────────── #
@@ -737,6 +740,19 @@ class ImmuneCogGraph(CogGraph):
 
     def _update_hack_channels(self):
         """每 step 调用：检查 hack 点变化，更新 self._hack_onehot"""
+        # 检查是否有新的黑客类型出现，若有则扩充 embedding
+        for hack_name in self.env.hack_types.keys():
+            if hack_name not in self.hack_type_to_idx:
+                new_idx = len(self.hack_types)
+                self.hack_types.append(hack_name)
+                self.hack_type_to_idx[hack_name] = new_idx
+                old_weight = self.hack_type_embedding.weight.data
+                new_embed = nn.Embedding(len(self.hack_types), 1).to(self.device)
+                with torch.no_grad():
+                    new_embed.weight[:-1].copy_(old_weight)
+                    new_embed.weight[-1].uniform_(-0.05, 0.05)
+                self.hack_type_embedding = new_embed
+                logger.info(f"[Hack类型扩展] 新增类型 {hack_name}，embedding size → {len(self.hack_types)}")
         new_keys = set(self.env.hacks.keys())
         if new_keys == self._last_hack_keys:
             return
@@ -1017,82 +1033,78 @@ class ImmuneCogGraph(CogGraph):
                 if len(filtered_candidates) == max_k:  # 凑够 5 个就停
                     break
 
-            # 走到这里：
-            #   • filtered_candidates 长度 ∈ [0, 5]
-            #   • 若 ==0 → 后续代码将 fallback 到 curiosity
-            #   • 若 1-5 → 后续代码会从中挑最近的一个作为 personal_goal
+            score_lookup = {indices[i].item(): float(threat_probs[i].item()) for i in range(indices.numel())}
 
-            # 2.4) 如果没有任何“未满 3 人”的威胁点，就退到好奇点
             if not filtered_candidates:
-                visited = self.env.visited_map
-                age_map = self.visit_age_map
-                never_visited_mask = ~visited
-                cooldown = getattr(u, "intrinsic_cooldown", 0)
-                long_time_mask = (age_map >= cooldown)
-                candidate_mask = never_visited_mask | long_time_mask
-                cand = torch.nonzero(candidate_mask)
-                if cand.numel() == 0:
-                    return
-                ex, ey = u.position
-                mask_far = []
-                for (yy, xx) in cand.tolist():
-                    mask_far.append(abs(xx - ex) + abs(yy - ey) >= MIN_PATROL_DIST)
-                mask_far = torch.tensor(mask_far, dtype=torch.bool, device=cand.device)
-                if mask_far.any():
-                    cand = cand[mask_far]
-                sel = torch.randint(0, cand.size(0), (1,), generator=self._rng).item()
-                ty, tx = cand[sel].tolist()
-                u.personal_goal = (tx, ty)
-                u.goal_type = "curiosity"
-                u._last_intrinsic_step = self.current_step
-                logger.info(f"[好奇点 fallback] 给 emitter {u.id} 分配新好奇点：({tx},{ty})")
+                self._assign_curiosity_goal(u)
                 return
 
-            # 2.5) 从这最多 max_k 个“未满员”候选里，选与当前 emitter 最近的一个
-            ux, uy = u.position
-            best_flat, best_dist = None, None
-            for flat_idx in filtered_candidates:
-                cx, cy = flat_idx % size, flat_idx // size
-                d = abs(cx - ux) + abs(cy - uy)
-                if best_dist is None or d < best_dist:
-                    best_dist, best_flat = d, flat_idx
+            choice, meta = self.adaptive_guidance.select_goal(
+                emitter_id=u.id,
+                emitter_pos=u.position,
+                candidates=filtered_candidates,
+                threat_scores=score_lookup,
+                step=self.current_step,
+            )
 
-            goal_x, goal_y = best_flat % size, best_flat // size
+            if choice is None:
+                self._assign_curiosity_goal(u)
+                return
 
-            # 2.6) 标记 goal_type 并赋给 emitter
+            goal_x, goal_y = choice % size, choice // size
+
             if (goal_x, goal_y) in self.known_hacks:
                 u.goal_type = "hack"
             else:
                 u.goal_type = "infection"
             u.personal_goal = (goal_x, goal_y)
+            u.assignment_source = ASSIGNMENT_LEARNED
+            u.assignment_trace = {
+                "pos": (goal_x, goal_y),
+                "step": self.current_step,
+                "meta": meta,
+                "source": ASSIGNMENT_LEARNED,
+            }
             u._last_intrinsic_step = self.current_step
-            logger.info(f"[学习+距离+Capacity] 给 emitter {u.id} 分配目标 → ({goal_x},{goal_y}), 距离={best_dist}")
+            logger.info(
+                f"[学习调度] emitter {u.id} 目标 → ({goal_x},{goal_y}), 策略={meta.get('strategy', 'exploit')}"
+            )
             return
 
         # —— ③ 如果没有任何威胁，或者前面都返回后，这里走“好奇点”逻辑 —— #
         if getattr(u, "goal_type", None) is None:
-            visited = self.env.visited_map
-            age_map = self.visit_age_map
-            never_visited_mask = ~visited
-            cooldown = getattr(u, "intrinsic_cooldown", 0)
-            long_time_mask = (age_map >= cooldown)
-            candidate_mask = never_visited_mask | long_time_mask
-            cand = torch.nonzero(candidate_mask)
-            if cand.numel() == 0:
-                return
-            ex, ey = u.position
-            mask_far = []
-            for (yy, xx) in cand.tolist():
-                mask_far.append(abs(xx - ex) + abs(yy - ey) >= MIN_PATROL_DIST)
-            mask_far = torch.tensor(mask_far, dtype=torch.bool, device=cand.device)
-            if mask_far.any():
-                cand = cand[mask_far]
-            sel = torch.randint(0, cand.size(0), (1,), generator=self._rng).item()
-            ty, tx = cand[sel].tolist()
-            u.personal_goal = (tx, ty)
-            u.goal_type = "curiosity"
-            u._last_intrinsic_step = self.current_step
-            logger.info(f"[好奇点] 给 emitter {u.id} 分配新好奇点：({tx},{ty})")
+            self._assign_curiosity_goal(u)
+
+    def _assign_curiosity_goal(self, unit):
+        visited = self.env.visited_map
+        age_map = self.visit_age_map
+        never_visited_mask = ~visited
+        cooldown = getattr(unit, "intrinsic_cooldown", 0)
+        long_time_mask = (age_map >= cooldown)
+        candidate_mask = never_visited_mask | long_time_mask
+        cand = torch.nonzero(candidate_mask)
+        if cand.numel() == 0:
+            return
+        ex, ey = unit.position
+        mask_far = []
+        for (yy, xx) in cand.tolist():
+            mask_far.append(abs(xx - ex) + abs(yy - ey) >= MIN_PATROL_DIST)
+        mask_far = torch.tensor(mask_far, dtype=torch.bool, device=cand.device)
+        if mask_far.any():
+            cand = cand[mask_far]
+        sel = torch.randint(0, cand.size(0), (1,), generator=self._rng).item()
+        ty, tx = cand[sel].tolist()
+        unit.personal_goal = (tx, ty)
+        unit.goal_type = "curiosity"
+        unit.assignment_source = ASSIGNMENT_SELF
+        unit.assignment_trace = {
+            "pos": (tx, ty),
+            "step": self.current_step,
+            "meta": {"strategy": "curiosity"},
+            "source": ASSIGNMENT_SELF,
+        }
+        unit._last_intrinsic_step = self.current_step
+        logger.info(f"[好奇点] 给 emitter {unit.id} 分配新好奇点：({tx},{ty})")
 
     def processor_forward(self, sensor_out: torch.Tensor):
         if sensor_out.dim() == 1:
@@ -1357,6 +1369,7 @@ class ImmuneCogGraph(CogGraph):
 
         # 7) 更新目标向量
         self._update_target_vector()
+        self.adaptive_guidance.resize(self.env.size)
 
         logger.warning(
             f"[Curriculum升级] 第 {self.current_step} 步："
@@ -1587,8 +1600,8 @@ class ImmuneCogGraph(CogGraph):
             span = self.current_step - self.kill_stats["last_reset"]
             logger.warning(
                 f"[击杀统计] 过去 {span} 步："
-                f"病毒-自主={self.kill_stats['self_direct']}, 病毒-指引={self.kill_stats['guided']} | "
-                f"Hack-自主={self.hack_kill_stats['self_direct']}, Hack-指引={self.hack_kill_stats['guided']}"
+                f"病毒-自主={self.kill_stats[ASSIGNMENT_SELF]}, 病毒-学习={self.kill_stats[ASSIGNMENT_LEARNED]} | "
+                f"Hack-自主={self.hack_kill_stats[ASSIGNMENT_SELF]}, Hack-学习={self.hack_kill_stats[ASSIGNMENT_LEARNED]}"
             )
             logger.warning(
                 f"Sensor 数量：{self.sensor_count}, Processor 数量：{self.processor_count}, "
@@ -1596,8 +1609,8 @@ class ImmuneCogGraph(CogGraph):
             )
 
         if self.current_step - self.kill_stats["last_reset"] >= 1000:
-            self.kill_stats.update(self_direct=0, guided=0, last_reset=self.current_step)
-            self.hack_kill_stats.update(self_direct=0, guided=0)
+            self.kill_stats.update({ASSIGNMENT_SELF: 0, ASSIGNMENT_LEARNED: 0, "last_reset": self.current_step})
+            self.hack_kill_stats.update({ASSIGNMENT_SELF: 0, ASSIGNMENT_LEARNED: 0})
 
 
     def _update_target_weights(self):
@@ -1705,6 +1718,8 @@ class ImmuneCogGraph(CogGraph):
             if u.role == "emitter":
                 # 同步最新的全局目标向量
                 u.goal_vec = self.tv_cached
+                u.assignment_source = ASSIGNMENT_SELF
+                u.assignment_trace = None
 
             # 计算本轮 expected 输入维度（虽然这里没真正用到 exp_in 做后续处理，但保留原注释意图）
             if u.role == "sensor":
@@ -1956,13 +1971,18 @@ class ImmuneCogGraph(CogGraph):
             # —— ④ 更新 kill_stats、virus_kill_stats_by_type、unit.cleared_positions —— #
             hits = len(all_to_clear)
             if hits > 0:
-                src = "guided" if getattr(unit, "guided_this_round", False) else "self_direct"
+                src = getattr(unit, "assignment_source", ASSIGNMENT_SELF)
+                if src not in self.kill_stats:
+                    self.kill_stats[src] = 0
                 unit.cleared_positions = set()
                 for (x, y, virus_type) in all_to_clear:
                     self.kill_stats[src] += 1
                     bucket_v = self.virus_kill_stats_by_type.setdefault(
-                        virus_type, {"self_direct": 0, "guided": 0}
+                        virus_type,
+                        {ASSIGNMENT_SELF: 0, ASSIGNMENT_LEARNED: 0},
                     )
+                    if src not in bucket_v:
+                        bucket_v[src] = 0
                     bucket_v[src] += 1
                     unit.cleared_positions.add((x, y))
 
@@ -1976,7 +1996,7 @@ class ImmuneCogGraph(CogGraph):
                 # —— ⑥ 统一奖励：根据“扩散点=0.01；命名点=1.0”与“全命名点×5倍”计算 —— #
                 curr_inf_count = int((self.env.infected_map > 0.04).sum().item())
                 scale = 1.0 / (1 + curr_inf_count)
-                factor = GUIDED_FACTOR if getattr(unit, "guided_this_round", False) else 0.1
+                factor = LEARNED_FACTOR if src == ASSIGNMENT_LEARNED else 0.1
 
                 weighted_hits = 0.0
                 for (_, _, virus_type) in all_to_clear:
@@ -1998,11 +2018,19 @@ class ImmuneCogGraph(CogGraph):
                 total_reward += reward
 
                 logger.warning(
-                    f"[清理奖励] 总权重 {weighted_hits:.2f}，"
+                    f"[清理奖励] 来源={src}，"
+                    f"learning倍率 {factor:.2f}，"
+                    f"总权重 {weighted_hits:.2f}，"
                     f"带名字点倍率 {multiplier}×，"
                     f"场上感染数 {curr_inf_count} → 缩放 {scale:.3f}，"
                     f"最终能量 {reward:.2f}"
                 )
+
+                trace = getattr(unit, "assignment_trace", None)
+                if trace and trace.get("source") == ASSIGNMENT_LEARNED:
+                    latency = self.current_step - trace.get("step", self.current_step)
+                    target_pos = trace.get("pos", getattr(unit, "personal_goal", (0, 0)))
+                    self.adaptive_guidance.register_feedback(target_pos, reward, latency)
 
                 # —— ⑦ 距离 bonus & 上游 processor 分成 —— #
                 infected_points = torch.nonzero(self.env.infected_map > 0.04).tolist()
@@ -2051,13 +2079,17 @@ class ImmuneCogGraph(CogGraph):
             # —— ④ 更新 hack_kill_stats、hack_kill_stats_by_type、unit.cleared_hack —— #
             hits = len(all_to_clear)
             if hits > 0:
-                src = "guided" if getattr(unit, "guided_this_round", False) else "self_direct"
+                src = getattr(unit, "assignment_source", ASSIGNMENT_SELF)
+                if src not in self.hack_kill_stats:
+                    self.hack_kill_stats[src] = 0
                 unit.cleared_hack = set()
                 for (x, y, hack_type) in all_to_clear:
                     self.hack_kill_stats[src] += 1
                     bucket_h = self.hack_kill_stats_by_type.setdefault(
-                        hack_type, {"self_direct": 0, "guided": 0}
+                        hack_type, {ASSIGNMENT_SELF: 0, ASSIGNMENT_LEARNED: 0}
                     )
+                    if src not in bucket_h:
+                        bucket_h[src] = 0
                     bucket_h[src] += 1
                     unit.cleared_hack.add((x, y))
 
@@ -2071,7 +2103,7 @@ class ImmuneCogGraph(CogGraph):
                 # —— ⑥ 统一奖励：根据“传播点=0.01；命名点=1.0”与“全命名点×5倍”计算 —— #
                 curr_hack_count = len(self.env.hacks)
                 scale = 1.0 / (1 + curr_hack_count)
-                factor = GUIDED_FACTOR if getattr(unit, "guided_this_round", False) else 0.1
+                factor = LEARNED_FACTOR if src == ASSIGNMENT_LEARNED else 0.1
 
                 weighted_hits = 0.0
                 for (_, _, hack_type) in all_to_clear:
@@ -2093,11 +2125,19 @@ class ImmuneCogGraph(CogGraph):
                 total_reward += hack_reward
 
                 logger.warning(
-                    f"[黑客批量奖励] 总权重 {weighted_hits:.2f}，"
+                    f"[黑客批量奖励] 来源={src}，"
+                    f"learning倍率 {factor:.2f}，"
+                    f"总权重 {weighted_hits:.2f}，"
                     f"带名字点倍率 {multiplier}×，"
                     f"场上剩余 hack {curr_hack_count} → 缩放 {scale:.3f}，"
                     f"最终能量 {hack_reward:.2f}"
                 )
+
+                trace = getattr(unit, "assignment_trace", None)
+                if trace and trace.get("source") == ASSIGNMENT_LEARNED:
+                    latency = self.current_step - trace.get("step", self.current_step)
+                    target_pos = trace.get("pos", getattr(unit, "personal_goal", (0, 0)))
+                    self.adaptive_guidance.register_feedback(target_pos, hack_reward, latency)
 
                 # —— 距离 bonus & 上游 processor 分成 —— #
                 hack_positions = [(x, y) for (x, y, _) in all_to_clear]
@@ -2451,8 +2491,8 @@ class ImmuneCogGraph(CogGraph):
                 base_reward = 0.6
                 scale = 1.0 / (1.0 + curr_inf_count)
                 reward = base_reward * scale
-                if getattr(u_k, "guided_this_round", False):
-                    reward *= GUIDED_FACTOR
+                if getattr(u_k, "assignment_source", ASSIGNMENT_SELF) == ASSIGNMENT_LEARNED:
+                    reward *= LEARNED_FACTOR
 
                 u_k.energy += reward
                 u_k.meta.record(action="defense", reward=reward)
@@ -2477,8 +2517,8 @@ class ImmuneCogGraph(CogGraph):
             # ==== NEW：hack 清理奖励（若 cleared_hack 属性存在）====
             if hasattr(u_k, "cleared_hack") and u_k.cleared_hack:
                 hack_r = 1.2
-                if getattr(u_k, "guided_this_round", False):
-                    hack_r *= GUIDED_FACTOR
+                if getattr(u_k, "assignment_source", ASSIGNMENT_SELF) == ASSIGNMENT_LEARNED:
+                    hack_r *= LEARNED_FACTOR
 
                 curr_hack_count = len(self.env.hacks)
                 scale = 1.0 / (1 + curr_hack_count)
@@ -2588,7 +2628,10 @@ class ImmuneCogGraph(CogGraph):
             if unit.role != "emitter" or not hasattr(unit, "get_output"):
                 continue
 
-            unit.guided_this_round = False
+            if not hasattr(unit, "assignment_source"):
+                unit.assignment_source = ASSIGNMENT_SELF
+            if not hasattr(unit, "assignment_trace"):
+                unit.assignment_trace = None
             action_vec = unit.get_output()  # [3*seq_len]
             action = self._decode_action_from_output(unit, action_vec)
 

--- a/adaptive_guidance.py
+++ b/adaptive_guidance.py
@@ -1,0 +1,109 @@
+"""Learning-based emitter coordination utilities."""
+from __future__ import annotations
+
+from collections import deque
+from typing import Dict, Iterable, Optional, Tuple
+import random
+
+import torch
+
+
+ASSIGNMENT_SELF = "self_direct"
+ASSIGNMENT_LEARNED = "learned"
+
+
+class AdaptiveGuidanceModule:
+    """Contextual bandit that learns which cells to assign to emitters."""
+
+    def __init__(
+        self,
+        grid_size: int,
+        device: torch.device | str = "cpu",
+        lr: float = 0.15,
+        gamma: float = 0.95,
+        epsilon: float = 0.1,
+        history: int = 2048,
+    ) -> None:
+        self.device = torch.device(device)
+        self.grid_size = grid_size
+        self.lr = lr
+        self.gamma = gamma
+        self.epsilon = epsilon
+        self.value_map = torch.zeros((grid_size, grid_size), dtype=torch.float32, device=self.device)
+        self.visit_counts = torch.zeros_like(self.value_map)
+        self.history = deque(maxlen=history)
+        self._rng = random.Random()
+
+    def resize(self, new_size: int) -> None:
+        if new_size == self.grid_size:
+            return
+        new_values = torch.zeros((new_size, new_size), dtype=self.value_map.dtype, device=self.device)
+        new_counts = torch.zeros_like(new_values)
+        min_size = min(new_size, self.grid_size)
+        new_values[:min_size, :min_size] = self.value_map[:min_size, :min_size]
+        new_counts[:min_size, :min_size] = self.visit_counts[:min_size, :min_size]
+        self.value_map = new_values
+        self.visit_counts = new_counts
+        self.grid_size = new_size
+
+    def select_goal(
+        self,
+        emitter_id: int,
+        emitter_pos: Tuple[int, int],
+        candidates: Iterable[int],
+        threat_scores: Dict[int, float],
+        step: int,
+    ) -> Tuple[Optional[int], Dict[str, float]]:
+        cand_list = list(candidates)
+        if not cand_list:
+            return None, {}
+
+        if self._rng.random() < self.epsilon:
+            choice = self._rng.choice(cand_list)
+            return choice, {"strategy": "explore", "score": 0.0}
+
+        ex, ey = emitter_pos
+        best_flat = None
+        best_score = None
+        for flat in cand_list:
+            x = flat % self.grid_size
+            y = flat // self.grid_size
+            distance = abs(x - ex) + abs(y - ey) + 1
+            learned = float(self.value_map[y, x].item())
+            prior = threat_scores.get(flat, 0.0)
+            visits = float(self.visit_counts[y, x].item())
+            confidence = 1.0 / (1.0 + visits)
+            score = learned + confidence * prior - 0.05 * distance
+            if best_score is None or score > best_score:
+                best_score = score
+                best_flat = flat
+
+        return best_flat, {"strategy": "exploit", "score": best_score or 0.0}
+
+    def register_feedback(
+        self,
+        position: Tuple[int, int],
+        reward: float,
+        latency: int,
+    ) -> None:
+        x, y = position
+        if x < 0 or y < 0 or x >= self.grid_size or y >= self.grid_size:
+            return
+        decay = self.gamma ** max(latency, 1)
+        target = reward * decay
+        old_value = self.value_map[y, x]
+        self.value_map[y, x] = old_value + self.lr * (target - old_value)
+        self.visit_counts[y, x] += 1
+
+    def snapshot(self) -> Dict[str, torch.Tensor]:
+        return {
+            "values": self.value_map.detach().clone(),
+            "counts": self.visit_counts.detach().clone(),
+        }
+
+
+__all__ = [
+    "AdaptiveGuidanceModule",
+    "ASSIGNMENT_SELF",
+    "ASSIGNMENT_LEARNED",
+]

--- a/adaptive_threats.py
+++ b/adaptive_threats.py
@@ -1,0 +1,276 @@
+"""Adaptive threat generation models for EvoCore-AI.
+
+These lightweight evolution modules mutate base virus and hacker
+profiles, track feedback from ImmuneCogGraph, and continuously adjust
+spawn parameters so that the immune system must learn instead of relying
+on hard-coded guidance.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
+import random
+
+import torch
+
+
+@dataclass
+class ThreatProfile:
+    """Describes a single evolved threat instance."""
+
+    name: str
+    params: Dict[str, float]
+    base_name: str
+    novelty: float
+    target: Optional[Tuple[int, int]] = None
+    metadata: Dict[str, float] = field(default_factory=dict)
+
+
+class _EMAStat:
+    """Tracks exponential moving averages for threat outcomes."""
+
+    def __init__(self, momentum: float = 0.9):
+        self.momentum = momentum
+        self.avg_reward = 0.0
+        self.avg_lifetime = 0.0
+        self.num_samples = 0
+
+    def update(self, reward: float, lifetime: float) -> None:
+        self.num_samples += 1
+        beta = 1.0 - self.momentum
+        self.avg_reward = self.momentum * self.avg_reward + beta * reward
+        self.avg_lifetime = self.momentum * self.avg_lifetime + beta * lifetime
+
+    def score(self) -> float:
+        if self.num_samples == 0:
+            return 0.0
+        return self.avg_reward + 0.1 * self.avg_lifetime
+
+
+def _clamp(value: float, lo: float, hi: float) -> float:
+    return max(lo, min(hi, value))
+
+
+class VirusEvolutionModel:
+    """Evolves new virus behaviour profiles from base templates."""
+
+    def __init__(
+        self,
+        base_catalog: Dict[str, Dict[str, float]],
+        device: torch.device | str = "cpu",
+        mutation_rate: float = 0.12,
+    ) -> None:
+        self.device = torch.device(device)
+        self.base_catalog = {k: dict(v) for k, v in base_catalog.items()}
+        self.mutation_rate = mutation_rate
+        self.stats: Dict[str, _EMAStat] = {name: _EMAStat() for name in base_catalog}
+        self._rng = random.Random()
+        self._mutation_id = 0
+
+    def register_feedback(self, profile_name: str, reward: float, lifetime: float) -> None:
+        if profile_name not in self.stats:
+            self.stats[profile_name] = _EMAStat()
+        self.stats[profile_name].update(reward, lifetime)
+
+    def population_pressure(self, active_ratio: float, step_ratio: float) -> float:
+        return _clamp(0.2 + 0.6 * active_ratio + 0.4 * step_ratio, 0.1, 1.5)
+
+    def _select_base(self) -> str:
+        names = list(self.stats)
+        weights = []
+        for name in names:
+            stat = self.stats[name]
+            base_weight = 1.0
+            if stat.num_samples > 0:
+                base_weight += stat.score()
+            weights.append(max(base_weight, 0.05))
+        total = sum(weights)
+        if total <= 0:
+            return self._rng.choice(names)
+        probs = [w / total for w in weights]
+        return self._rng.choices(names, probs)[0]
+
+    def _mutate_value(self, value: float, pressure: float, scale: float = 1.0) -> float:
+        noise = self._rng.gauss(0.0, self.mutation_rate * pressure * scale)
+        return value * (1.0 + noise)
+
+    def _mutate_additive(self, value: float, pressure: float, scale: float = 1.0) -> float:
+        noise = self._rng.gauss(0.0, self.mutation_rate * pressure * scale)
+        return value + noise
+
+    def sample_profile(
+        self,
+        step: int,
+        active_infections: int,
+        grid_size: int,
+    ) -> ThreatProfile:
+        base_name = self._select_base()
+        base = self.base_catalog.get(base_name, {})
+        pressure = self.population_pressure(
+            active_ratio=active_infections / max(grid_size * grid_size, 1),
+            step_ratio=min(step / 5000.0, 1.0),
+        )
+
+        params = dict(base)
+        params["spread_prob"] = _clamp(
+            self._mutate_value(params.get("spread_prob", 0.1), pressure, scale=0.5),
+            0.01,
+            0.95,
+        )
+        params["stealth"] = _clamp(
+            self._mutate_additive(params.get("stealth", 0.0), pressure, scale=0.4),
+            0.0,
+            0.99,
+        )
+        params["power"] = _clamp(
+            self._mutate_value(params.get("power", 1.0), pressure, scale=0.3),
+            0.2,
+            5.0,
+        )
+
+        if params.get("burst", False) or self._rng.random() < 0.2 * pressure:
+            params["burst"] = True
+            base_chance = params.get("burst_chance", 0.25)
+            params["burst_chance"] = _clamp(
+                self._mutate_value(base_chance, pressure, scale=0.4),
+                0.05,
+                0.95,
+            )
+            base_area = params.get("burst_area", 2)
+            params["burst_area"] = int(
+                _clamp(round(self._mutate_additive(base_area, pressure, scale=1.0)), 1, 5)
+            )
+        else:
+            params["burst"] = False
+            params.pop("burst_chance", None)
+            params.pop("burst_area", None)
+
+        novelty = 0.0
+        name = base_name
+        if self._rng.random() < 0.35 * pressure:
+            name = f"{base_name}_m{self._mutation_id}"
+            self._mutation_id += 1
+            novelty = 1.0
+            self.base_catalog.setdefault(name, dict(params))
+            self.stats.setdefault(name, _EMAStat())
+
+        return ThreatProfile(name=name, params=params, base_name=base_name, novelty=novelty)
+
+
+class HackerEvolutionModel:
+    """Evolves hacker behaviours with contextual targeting."""
+
+    def __init__(
+        self,
+        base_catalog: Dict[str, Dict[str, float]],
+        device: torch.device | str = "cpu",
+        mutation_rate: float = 0.18,
+    ) -> None:
+        self.device = torch.device(device)
+        self.base_catalog = {k: dict(v) for k, v in base_catalog.items()}
+        self.stats: Dict[str, _EMAStat] = {name: _EMAStat() for name in base_catalog}
+        self.mutation_rate = mutation_rate
+        self._rng = random.Random()
+        self._mutation_id = 0
+
+    def register_feedback(self, profile_name: str, reward: float, lifetime: float) -> None:
+        if profile_name not in self.stats:
+            self.stats[profile_name] = _EMAStat()
+        self.stats[profile_name].update(reward, lifetime)
+
+    def _select_base(self) -> str:
+        names = list(self.stats)
+        weights = []
+        for name in names:
+            stat = self.stats[name]
+            weight = 1.0 + stat.score()
+            weights.append(max(weight, 0.05))
+        total = sum(weights)
+        if total <= 0:
+            return self._rng.choice(names)
+        probs = [w / total for w in weights]
+        return self._rng.choices(names, probs)[0]
+
+    def _mutate(self, value: float, pressure: float, scale: float = 1.0) -> float:
+        noise = self._rng.gauss(0.0, self.mutation_rate * pressure * scale)
+        return value * (1.0 + noise)
+
+    def _mutate_add(self, value: float, pressure: float, scale: float = 1.0) -> float:
+        noise = self._rng.gauss(0.0, self.mutation_rate * pressure * scale)
+        return value + noise
+
+    def sample_batch(
+        self,
+        step: int,
+        vulnerability: torch.Tensor,
+        login_failures: torch.Tensor,
+        privilege: torch.Tensor,
+        batch_size: int = 3,
+    ) -> List[ThreatProfile]:
+        grid_size = vulnerability.shape[0]
+        heat = (
+            vulnerability.to(self.device)
+            + 0.4 * login_failures.to(self.device)
+            + 0.6 * privilege.to(self.device)
+        )
+        flat_heat = heat.view(-1)
+        if flat_heat.numel() == 0:
+            return []
+        topk = min(batch_size, flat_heat.numel())
+        values, indices = torch.topk(flat_heat, topk)
+        pressure = _clamp(float(values.mean().item()), 0.1, 5.0)
+
+        profiles: List[ThreatProfile] = []
+        for idx in indices.tolist():
+            x = idx % grid_size
+            y = idx // grid_size
+            base_name = self._select_base()
+            base = self.base_catalog.get(base_name, {})
+
+            params = dict(base)
+            params["spawn_prob"] = _clamp(
+                self._mutate(params.get("spawn_prob", 0.01), pressure, scale=0.5),
+                0.001,
+                0.35,
+            )
+            params["stealth"] = _clamp(
+                self._mutate_add(params.get("stealth", 0.0), pressure, scale=0.3),
+                0.0,
+                0.99,
+            )
+            params["impact"] = _clamp(
+                self._mutate(params.get("impact", 1.0), pressure, scale=0.4),
+                0.2,
+                6.0,
+            )
+            params["max_fail"] = max(
+                1.0,
+                self._mutate(params.get("max_fail", 3.0), pressure, scale=0.2),
+            )
+
+            novelty = 0.0
+            name = base_name
+            if self._rng.random() < 0.3 * pressure:
+                name = f"{base_name}_m{self._mutation_id}"
+                self._mutation_id += 1
+                novelty = 1.0
+                self.base_catalog.setdefault(name, dict(params))
+                self.stats.setdefault(name, _EMAStat())
+
+            profiles.append(
+                ThreatProfile(
+                    name=name,
+                    params=params,
+                    base_name=base_name,
+                    novelty=novelty,
+                    target=(x, y),
+                )
+            )
+        return profiles
+
+
+__all__ = [
+    "ThreatProfile",
+    "VirusEvolutionModel",
+    "HackerEvolutionModel",
+]

--- a/emitter_actions.py
+++ b/emitter_actions.py
@@ -57,14 +57,9 @@ class EmitterActions:
                     continue
 
                 # 对 (nx, ny) 执行“黑客防御”单点清理
-                env.privilege_level[ny, nx] = 0.0
-                env.login_failures[ny, nx]  = 0.0
-                env.vulnerability[ny, nx]  *= 0.5
-                env.hack_strength[ny, nx]   = 0.0
-                env.hacks.pop((nx, ny), None)
+                env.clear_hack((nx, ny))
                 logger.info(f"[HACK_DEFENSE] 在 ({nx},{ny}) 执行黑客防御（3×3 范围）")
 
-                # 如果你维护了 hack_history，需要同步减一：
                 env.hack_history[ny, nx] = max(env.hack_history[ny, nx] - 1.0, 0.0)
 
 

--- a/env_net.py
+++ b/env_net.py
@@ -1,7 +1,10 @@
 import torch
 import random
 from collections import deque
+from typing import Tuple
 import torch.nn.functional as F
+
+from adaptive_threats import HackerEvolutionModel, VirusEvolutionModel
 
 class GridSecurityEnv:
     def __init__(self, size=10, device='cpu', difficulty_ramp=5000, spawn_interval=200):
@@ -38,6 +41,24 @@ class GridSecurityEnv:
 
         # 统计“随机更新”步数，用于降低频率
         self._rand_update_counter = 0
+
+        # —— 基础威胁模板 —— #
+        self._base_attack_templates = {
+            'worm':    {'spread_prob': 0.2, 'stealth': 0.0, 'burst': False, 'power': 1.0},
+            'trojan':  {'spread_prob': 0.05, 'stealth': 0.6, 'burst': False, 'power': 1.0},
+            'scan':    {'spread_prob': 0.0, 'stealth': 1.0, 'burst': True,  'burst_chance': 0.4, 'burst_area': 3, 'power': 0.8},
+            'ransom':  {'spread_prob': 0.1, 'stealth': 0.3, 'burst': True,  'burst_chance': 0.3, 'burst_area': 2, 'power': 1.2},
+            'apt':     {'spread_prob': 0.15, 'stealth': 0.8, 'burst': True,  'burst_chance': 0.4, 'burst_area': 4, 'power': 1.5},
+        }
+        self._base_hack_templates = {
+            'bruteforce':      {'spawn_prob': 0.02, 'max_fail': 5.0, 'impact': 0.8, 'stealth': 0.2},
+            'phishing':        {'spawn_prob': 0.01, 'stealth': 0.8, 'impact': 1.2, 'max_fail': 2.0},
+            'lateral_move':    {'spawn_prob': 0.005, 'stealth': 0.4, 'impact': 0.9, 'max_fail': 3.0},
+            'privilege_escalation': {'spawn_prob': 0.003, 'stealth': 0.6, 'impact': 1.5, 'max_fail': 4.0},
+        }
+
+        self.virus_model = VirusEvolutionModel(self._base_attack_templates, device=self.device)
+        self.hacker_model = HackerEvolutionModel(self._base_hack_templates, device=self.device)
 
         self.infected_duration_map = torch.zeros((self.size, self.size), dtype=torch.int32, device=self.device)
         self.reset()
@@ -82,22 +103,11 @@ class GridSecurityEnv:
         self.login_failures  = torch.zeros_like(self.infected_map)
 
         # 支持的攻击类型及参数
-        self.attack_types = {
-            'worm':    {'spread_prob': 0.2, 'stealth': 0.0, 'burst': False},
-            'trojan':  {'spread_prob': 0.05, 'stealth': 0.6, 'burst': False},
-            'scan':    {'spread_prob': 0.0, 'stealth': 1.0, 'burst': True,  'burst_chance': 0.4, 'burst_area': 3},
-            'ransom':  {'spread_prob': 0.1, 'stealth': 0.3, 'burst': True,  'burst_chance': 0.3, 'burst_area': 2},
-            'apt':     {'spread_prob': 0.15, 'stealth': 0.8, 'burst': True,  'burst_chance': 0.4, 'burst_area': 4},
-        }
+        self.attack_types = {k: dict(v) for k, v in self._base_attack_templates.items()}
 
         self.attacks = {}
         self.hack_spawn_interval = 20
-        self.hack_types = {
-            'bruteforce':      {'spawn_prob': 0.02, 'max_fail': 5},
-            'phishing':        {'spawn_prob': 0.01, 'stealth':0.8},
-            'lateral_move':    {'spawn_prob': 0.005},
-            'privilege_escalation': {'spawn_prob': 0.003}
-        }
+        self.hack_types = {k: dict(v) for k, v in self._base_hack_templates.items()}
         self.hacks = {}  # 当前活跃的黑客事件: dict[(x,y)]→{type,…}
         # if self.step_count >= 0:  # 比如只在后期才允许初始病毒出现
         #     self._spawn_attack(initial=True)
@@ -132,27 +142,40 @@ class GridSecurityEnv:
         - 会根据当前 step_count 决定允许的攻击类型（早期较弱）
         - 随机选择攻击类型与位置
         """
-        if self.step_count < self.difficulty_ramp * 0.3:
-            available = ['worm', 'trojan']
-        elif self.step_count < self.difficulty_ramp * 0.6:
-            available = ['worm', 'trojan', 'scan', 'ransom']
+        profile = self.virus_model.sample_profile(
+            step=self.step_count,
+            active_infections=int((self.infected_map > 0.04).sum().item()),
+            grid_size=self.size,
+        )
+        if profile.name not in self.attack_types:
+            self.attack_types[profile.name] = dict(profile.params)
+
+        params = self.attack_types[profile.name]
+
+        heat = (self.behavior_score + 0.5 * self.net_traffic + 0.1).clamp(min=0.0)
+        flat_heat = heat.view(-1)
+        if float(flat_heat.sum().item()) > 0:
+            idx = torch.multinomial(flat_heat / flat_heat.sum(), 1).item()
+            x = idx % self.size
+            y = idx // self.size
         else:
-            available = list(self.attack_types.keys())
+            x = random.randint(0, self.size - 1)
+            y = random.randint(0, self.size - 1)
 
-        attack_type = random.choice(available)
-        x = random.randint(0, self.size - 1)
-        y = random.randint(0, self.size - 1)
-        params = self.attack_types[attack_type]
-        self.attacks[(x, y)] = {'type': attack_type, 'power': params.get('power', 1.0)}
+        power = params.get('power', 1.0)
+        self.attacks[(x, y)] = {
+            'type': profile.name,
+            'power': power,
+            'profile_name': profile.name,
+            'spawn_step': self.step_count,
+        }
 
-        self.infected_map[y, x] = 1.0
-        self.infection_strength[y, x] = params.get('power', 1.0)
+        self.infected_map[y, x] = max(self.infected_map[y, x], power)
+        self.infection_strength[y, x] = power
 
-        # —— 新增：把 (x,y) 对应的扁平索引设为 attack_type 的序号 —— #
         flat_idx = y * self.size + x
-        type_idx = list(self.attack_types).index(attack_type)
+        type_idx = list(self.attack_types).index(profile.name)
         self._attack_type_flat[flat_idx] = type_idx
-        # 同时把新键加入 _last_attack_keys（如果 _spawn_attack 也可能在 step() 里调用多次，保证最终增量同步）
         self._last_attack_keys.add((x, y))
 
     def _expand_environment(self, growth: int = 2):
@@ -432,14 +455,37 @@ class GridSecurityEnv:
 
         # —— 调整：每 hack_spawn_interval 步才做一次 spawn —— #
         if self.step_count % self.hack_spawn_interval == 0:
-            for ht, params in self.hack_types.items():
-                if random.random() < params['spawn_prob']:
+            profiles = self.hacker_model.sample_batch(
+                step=self.step_count,
+                vulnerability=self.vulnerability,
+                login_failures=self.login_failures,
+                privilege=self.privilege_level,
+            )
+            difficulty = min(1.5, 0.5 + self.step_count / max(self.difficulty_ramp, 1))
+            for profile in profiles:
+                if profile.name not in self.hack_types:
+                    self.hack_types[profile.name] = dict(profile.params)
+                params = self.hack_types[profile.name]
+                spawn_prob = params.get('spawn_prob', 0.01) * difficulty
+                if random.random() >= spawn_prob:
+                    continue
+                if profile.target is not None:
+                    x, y = profile.target
+                else:
                     x, y = random.randrange(self.size), random.randrange(self.size)
-                    self.hacks[(x,y)] = {'type': ht, 'power': params.get('stealth',1.0)}
-                    # 马上标记一次
-                    self.hack_history[y,x]  += 1
-                    self.hack_strength[y,x]  = params.get('stealth',1.0)
-                    self.privilege_level[y, x] = 1.0
+                x = int(max(0, min(float(x), self.size - 1)))
+                y = int(max(0, min(float(y), self.size - 1)))
+                impact = params.get('impact', params.get('stealth', 1.0))
+                self.hacks[(x, y)] = {
+                    'type': profile.name,
+                    'power': impact,
+                    'profile_name': profile.name,
+                    'spawn_step': self.step_count,
+                }
+                self.hack_history[y, x] += 1
+                self.hack_strength[y, x] = impact
+                self.privilege_level[y, x] = min(1.0, self.privilege_level[y, x] + impact)
+                self.login_failures[y, x] = max(self.login_failures[y, x], params.get('max_fail', 3.0))
 
             # 传播 or 行动
             new_hacks = {}
@@ -455,16 +501,25 @@ class GridSecurityEnv:
                 dst = dst[:, free]
                 if dst.numel():
                     vul = self.vulnerability[dst[1], dst[0]]
-                    p = 0.1  # 可以根据 hack 类型决定
-                    keep = (torch.rand_like(vul) < vul * p)
+                    keep = (torch.rand_like(vul) < vul * 0.1)
                     dst = dst[:, keep]
                     self.hack_history.index_put_((dst[1], dst[0]),
                                                  torch.ones(dst.shape[1], device=self.device),
                                                  accumulate=True)
-                    self.hack_strength[dst[1], dst[0]] = p
-                    self.privilege_level[dst[1], dst[0]] = p
-                    for x, y in zip(dst[0].tolist(), dst[1].tolist()):
-                        self.hacks[(x, y)] = {'type': 'lateral_move', 'power': p}
+                    for dx, dy in zip(dst[0].tolist(), dst[1].tolist()):
+                        parent_key = random.choice(list(self.hacks.keys()))
+                        parent = self.hacks[parent_key]
+                        impact = parent.get('power', 0.5)
+                        self.hack_strength[dy, dx] = impact
+                        self.privilege_level[dy, dx] = max(self.privilege_level[dy, dx], impact)
+                        new_hacks[(dx, dy)] = {
+                            'type': parent.get('type', 'lateral_move'),
+                            'power': impact,
+                            'profile_name': parent.get('profile_name', parent.get('type', 'lateral_move')),
+                            'spawn_step': self.step_count,
+                        }
+            if new_hacks:
+                self.hacks.update(new_hacks)
 
         # —— 更新黑客 one-hot —— #
         new_keys = set(self.hacks.keys())
@@ -551,9 +606,16 @@ class GridSecurityEnv:
         emitter 执行 block 动作：清除该格子感染
         """
         x, y = pos
+        info = self.attacks.pop((x, y), None)
         self.infected_map[y, x] = 0.0
         self.infection_strength[y, x] = 0.0
-        self.attacks.pop((x, y), None)
+        if info is not None:
+            lifetime = max(1, self.step_count - info.get('spawn_step', self.step_count))
+            self.virus_model.register_feedback(
+                info.get('profile_name', info.get('type', 'unknown')),
+                reward=1.0,
+                lifetime=lifetime,
+            )
 
     def quarantine_zone(self, pos):
         """
@@ -561,6 +623,21 @@ class GridSecurityEnv:
         """
         x, y = pos
         self.is_quarantined[y, x] = 1.0
+
+    def clear_hack(self, pos: Tuple[int, int]) -> None:
+        x, y = pos
+        info = self.hacks.pop((x, y), None)
+        self.privilege_level[y, x] = 0.0
+        self.login_failures[y, x] = 0.0
+        self.vulnerability[y, x] *= 0.5
+        self.hack_strength[y, x] = 0.0
+        if info is not None:
+            lifetime = max(1, self.step_count - info.get('spawn_step', self.step_count))
+            self.hacker_model.register_feedback(
+                info.get('profile_name', info.get('type', 'unknown')),
+                reward=1.0,
+                lifetime=lifetime,
+            )
 
     def mark_suspicious(self, pos):
         """

--- a/train_net_driven.py
+++ b/train_net_driven.py
@@ -53,13 +53,14 @@ def get_virus_type_stats(attacks: dict) -> str:
 
 def summarize_kills_by_type(kill_stats_by_type: dict) -> str:
     """
-    将 {"worm": {"self_direct": 3, "guided": 1}, ...} → "worm:4, trojan:1, ..."
+    将 {"worm": {"self_direct": 3, "learned": 1}, ...} → "worm:4, trojan:1, ..."
     """
-    return ", ".join(
-        f"{k}:{v['self_direct'] + v['guided']}"
-        for k, v in kill_stats_by_type.items()
-        if v["self_direct"] + v["guided"] > 0
-    ) or "None"
+    parts = []
+    for name, counters in kill_stats_by_type.items():
+        total = sum(counters.values())
+        if total > 0:
+            parts.append(f"{name}:{total}")
+    return ", ".join(parts) or "None"
 
 def main(cfg):
     global_step = 0
@@ -133,11 +134,11 @@ def main(cfg):
 
             # —— 1) 先记录“前一步”累计击杀数  —— #
             old_virus_kills = sum(
-                v["self_direct"] + v["guided"]
+                sum(v.values())
                 for v in graph.virus_kill_stats_by_type.values()
             )
             old_hack_kills = sum(
-                v["self_direct"] + v["guided"]
+                sum(v.values())
                 for v in graph.hack_kill_stats_by_type.values()
             )
 
@@ -149,11 +150,11 @@ def main(cfg):
 
             # —— 3) 紧接着记录“本步后”累计击杀数  —— #
             new_virus_kills = sum(
-                v["self_direct"] + v["guided"]
+                sum(v.values())
                 for v in graph.virus_kill_stats_by_type.values()
             )
             new_hack_kills = sum(
-                v["self_direct"] + v["guided"]
+                sum(v.values())
                 for v in graph.hack_kill_stats_by_type.values()
             )
 


### PR DESCRIPTION
## Summary
- add adaptive guidance and threat evolution modules so emitters learn targets from feedback instead of hard-coded guidance
- integrate evolving virus and hacker profiles into GridSecurityEnv, including feedback registration and shared clear_hack utility
- update ImmuneCogGraph, emitter actions, and training metrics to track learned vs self-directed performance and resize guidance state

## Testing
- python -m py_compile ImmuneCogGraph.py env_net.py adaptive_guidance.py adaptive_threats.py train_net_driven.py emitter_actions.py

------
https://chatgpt.com/codex/tasks/task_e_68dc4cb95e04832284527050fc93578e