### PR TITLE
Refactor CogUnit and graph modules into modular packages

### DIFF
--- a/coggraph/__init__.py
+++ b/coggraph/__init__.py
@@ -1,0 +1,5 @@
+"""CogGraph package exposing the main interfaces."""
+
+from .core import CogGraph, INPUT_CHANNELS
+
+__all__ = ["CogGraph", "INPUT_CHANNELS"]

--- a/coggraph/core.py
+++ b/coggraph/core.py
@@ -1,6 +1,6 @@
 # coggraph.py
 import uuid
-from CogUnit import CogUnit
+from cogunit import CogUnit
 import torch
 import random
 from env import GridEnvironment
@@ -24,6 +24,8 @@ import math
 from goal_generator import sample_unvisited, make_onehot
 from collections import Counter
 from self_model import build_self_model
+
+from .forward import ForwardMixin
 
 
 HIT_THRESH = 0.15          # 越大越宽松
@@ -108,7 +110,7 @@ def _build_transformer_block(D, H, device):
         return layer.to(device)
 
 
-class CogGraph:
+class CogGraph(ForwardMixin):
     """
     CogGraph 管理所有 CogUnit 的集合和连接关系：
     - 添加 / 删除单元
@@ -651,7 +653,7 @@ class CogGraph:
                 if hasattr(merged, "l1") and isinstance(merged.l1, nn.Linear):
                     if merged.l1.in_features < L:
                         # 复用之前的 expand_unit_dim，或简单重建一层
-                        from ImmuneCogGraph import ImmuneCogGraph
+                        from immune_cog_graph import ImmuneCogGraph
                         ImmuneCogGraph.expand_unit_dim(self, merged, L)
 
                 merged.age = int((u1.age + u2.age) / 2)
@@ -2511,143 +2513,9 @@ class CogGraph:
     # ------------------------------------------------------------------
 
 
-    def sensor_forward(self, env_state_np):
-        """
-        Args:
-            env_state_np : np.ndarray 或 torch.Tensor (size=N)
-        Returns:
-            torch.Tensor (size = env_state_np.size) —— 作为 sensor 输出
-        """
-        dev = self.device  # ← 统一目标设备
-        x = torch.as_tensor(env_state_np, dtype=torch.float32, device=dev).view(-1)
-
-        # ① —— 保底：传进来多少，就以 graph.processor_hidden_size 为准 ——
-        if any(u.input_size < self.processor_hidden_size for u in self.units if u.role == "sensor"):
-            for s in (u for u in self.units if u.role == "sensor"):
-                if s.input_size < self.processor_hidden_size:  # 只升不降
-                    self.expand_unit_dim(s, self.processor_hidden_size)
-        # —— 对齐到 processor_hidden_size ——
-        D = x.numel()
-        if D < self.processor_hidden_size:
-            pad = (0, self.processor_hidden_size - D)
-            x = torch.nn.functional.pad(x, pad)
-        elif D > self.processor_hidden_size:
-            x = x[: self.processor_hidden_size]
-
-        sensors = [u for u in self.units if u.get_role() == "sensor"]
-        if not sensors:
-            return x            # 无 sensor 时直接返回
-
-        if not RF.batch_sensor:  # ← 用 config 统一控制是否 batch 模式
-            for s in sensors:
-                s.update(x.unsqueeze(0))
-            return torch.stack([s.last_output for s in sensors], dim=0).mean(dim=0)
-
-        # ---- ⚡ 批量前向，仅做前向推理 ----
-        # ① 把 N 份输入堆在一起
-        batch_in = x.unsqueeze(0).repeat(len(sensors), 1)        # [N, D]
-
-        # ② 用 **首个 sensor 的网络结构** 复制一个临时 net
-        #    假设所有 sensor 都是相同的  Linear → ReLU → Linear
-        net = sensors[0].function
-        batch_out = net(batch_in)                                # [N, D]
-
-        # ③ 分别写回每个 sensor 的 last_output（不调用 update()，
-        #    省掉 split/代谢等逻辑；这些逻辑已经在 Graph.step() 外部显式调用）
-        for s, o in zip(sensors, batch_out):
-            s.last_output = o.detach()
-
-        return batch_out.mean(dim=0)       # 仍返回合并输出
 
 
-    def processor_forward(self, sensor_out):
-        """
-        Args:
-            sensor_out : torch.Tensor 1-D
-        Returns:
-            torch.Tensor (size = self.processor_hidden_size)
-        """
-        """批量或逐个执行 processor.update()."""
-        dev = self.device
-        sensor_out = sensor_out.to(dev)                   # (1,D)
 
-        # ① —— 保底：传进来多少，就以 graph.processor_hidden_size 为准 ——
-        if any(u.input_size < self.processor_hidden_size for u in self.units if u.role == "processor"):
-            for s in (u for u in self.units if u.role == "processor"):
-                if s.input_size < self.processor_hidden_size:  # 只升不降
-                    self.expand_unit_dim(s, self.processor_hidden_size)
-
-        procs = [u for u in self.units if u.role == "processor"]
-        if not procs:
-            return sensor_out
-
-        D = sensor_out.size(-1)
-        if RF.batch_processor:
-            # -------- 构造批输入 --------
-            batch_in = sensor_out.expand(len(procs), -1)  # [N,D]
-
-            # -------- 共享一张网络 --------
-            net = procs[0].function
-
-            ctx = (torch.autocast("cuda", dtype=torch.float16)
-                   if (RF.use_fp16 and dev.type == "cuda") else nullcontext())
-            with ctx, torch.inference_mode():
-                batch_out = net(batch_in)                 # [N,D]
-
-            # -------- 回写 last_output --------
-            for u, o in zip(procs, batch_out):
-                u.last_output = o.detach()
-            merged = batch_out.mean(dim=0)
-        else:
-            # 回退：逐个 update
-            outs = []
-            for p in procs:
-                p.update(sensor_out)
-                outs.append(p.get_output().view(-1))
-            merged = torch.stack(outs).mean(dim=0)
-
-        # —— 与旧实现相同的 pad / truncate —— #
-        if merged.numel() < self.processor_hidden_size:
-            merged = torch.nn.functional.pad(
-                merged, (0, self.processor_hidden_size - merged.numel()))
-        else:
-            merged = merged[: self.processor_hidden_size]
-        return merged.to(dev)
-
-    def emitter_forward(self, proc_out: torch.Tensor):
-        """
-        批量版：把 for-loop --> 单次 repeat + Linear，逻辑不变
-        """
-        # ---- 0) 统一输入形状 ----
-        if proc_out.dim() == 1:
-            proc_out = proc_out.unsqueeze(0)  # [1, H_p]
-
-        # ---- 1) 对齐到 emitter_hidden_size ----
-        vec = proc_out[0]
-        H_e = self.emitter_hidden_size
-        if vec.shape[0] < H_e:
-            vec = F.pad(vec, (0, H_e - vec.shape[0]))
-        elif vec.shape[0] > H_e:
-            vec = vec[:H_e]
-
-        # ---- 2) 收集 emitter 索引（一次性）----
-        em_idx = [i for i, u in enumerate(self.units) if u.role == "emitter"]
-        if not em_idx:  # 没有 emitter
-            return None
-
-        # 一次性把所有 emitter 线性层升维
-        for i in em_idx:
-            self.expand_unit_dim(self.units[i], H_e)
-
-        # ---- 3) 单次 forward ----
-        batch_in = vec.repeat(len(em_idx), 1)  # [N_emit, H_e]
-        logits = self.emitter_net(batch_in)  # [N_emit, seq_len]
-
-        # ---- 4) 写回各 emitter.last_output ----
-        for idx, lg in zip(em_idx, logits):
-            self.units[idx].last_output = lg.detach()
-
-        return logits
 
     def _rebuild_free_positions(self):
         """一次性扫描所有格子，生成安全出生点列表"""
@@ -2668,34 +2536,6 @@ class CogGraph:
         #     logger.debug(f" - {unit} → 连接数: {len(self.connections[unit.id])}")
         return
 
-    def collect_emitter_outputs(self):
-        """收集所有 emitter 输出并自动对齐到目标维度"""
-        aligned = []
-        for unit in self.units:
-            if unit.get_role() != "emitter":
-                continue
-
-            raw = unit.get_output().squeeze(0) if unit.get_output().dim() == 2 else unit.get_output()
-            vec = self._align_to_goal_dim(raw)
-
-            if vec.shape[-1] != self._goal_dim():
-                # 理论不会发生，安全检查
-                logger.warning(f"[警告] 对齐失败 {unit.id} 长度 {vec.shape[-1]}")
-                continue
-
-            aligned.append(vec.unsqueeze(0))
-
-        if aligned:
-            stacked = torch.cat(aligned, dim=0).to(self.device, non_blocking=True)      # [N, goal_dim]
-            logger.debug(
-                "[输出检查] Emitter 对齐后均值(前5) : %s",
-                stacked.mean(dim=0)[:5]
-            )
-
-            return stacked
-        else:
-            logger.debug("[输出检查] 当前没有活跃的 emitter 单元")
-            return None
 
 
 

--- a/coggraph/forward.py
+++ b/coggraph/forward.py
@@ -1,0 +1,182 @@
+"""Forward pass mixin for CogGraph."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+import torch.nn.functional as F
+from contextlib import nullcontext
+
+from config_runtime import RF
+from env import logger
+
+if TYPE_CHECKING:
+    from .core import CogGraph
+
+class ForwardMixin:
+    def sensor_forward(self, env_state_np):
+        """
+        Args:
+            env_state_np : np.ndarray 或 torch.Tensor (size=N)
+        Returns:
+            torch.Tensor (size = env_state_np.size) —— 作为 sensor 输出
+        """
+        dev = self.device  # ← 统一目标设备
+        x = torch.as_tensor(env_state_np, dtype=torch.float32, device=dev).view(-1)
+
+        # ① —— 保底：传进来多少，就以 graph.processor_hidden_size 为准 ——
+        if any(u.input_size < self.processor_hidden_size for u in self.units if u.role == "sensor"):
+            for s in (u for u in self.units if u.role == "sensor"):
+                if s.input_size < self.processor_hidden_size:  # 只升不降
+                    self.expand_unit_dim(s, self.processor_hidden_size)
+        # —— 对齐到 processor_hidden_size ——
+        D = x.numel()
+        if D < self.processor_hidden_size:
+            pad = (0, self.processor_hidden_size - D)
+            x = torch.nn.functional.pad(x, pad)
+        elif D > self.processor_hidden_size:
+            x = x[: self.processor_hidden_size]
+
+        sensors = [u for u in self.units if u.get_role() == "sensor"]
+        if not sensors:
+            return x            # 无 sensor 时直接返回
+
+        if not RF.batch_sensor:  # ← 用 config 统一控制是否 batch 模式
+            for s in sensors:
+                s.update(x.unsqueeze(0))
+            return torch.stack([s.last_output for s in sensors], dim=0).mean(dim=0)
+
+        # ---- ⚡ 批量前向，仅做前向推理 ----
+        # ① 把 N 份输入堆在一起
+        batch_in = x.unsqueeze(0).repeat(len(sensors), 1)        # [N, D]
+
+        # ② 用 **首个 sensor 的网络结构** 复制一个临时 net
+        #    假设所有 sensor 都是相同的  Linear → ReLU → Linear
+        net = sensors[0].function
+        batch_out = net(batch_in)                                # [N, D]
+
+        # ③ 分别写回每个 sensor 的 last_output（不调用 update()，
+        #    省掉 split/代谢等逻辑；这些逻辑已经在 Graph.step() 外部显式调用）
+        for s, o in zip(sensors, batch_out):
+            s.last_output = o.detach()
+
+        return batch_out.mean(dim=0)       # 仍返回合并输出
+
+    def processor_forward(self, sensor_out):
+        """
+        Args:
+            sensor_out : torch.Tensor 1-D
+        Returns:
+            torch.Tensor (size = self.processor_hidden_size)
+        """
+        """批量或逐个执行 processor.update()."""
+        dev = self.device
+        sensor_out = sensor_out.to(dev)                   # (1,D)
+
+        # ① —— 保底：传进来多少，就以 graph.processor_hidden_size 为准 ——
+        if any(u.input_size < self.processor_hidden_size for u in self.units if u.role == "processor"):
+            for s in (u for u in self.units if u.role == "processor"):
+                if s.input_size < self.processor_hidden_size:  # 只升不降
+                    self.expand_unit_dim(s, self.processor_hidden_size)
+
+        procs = [u for u in self.units if u.role == "processor"]
+        if not procs:
+            return sensor_out
+
+        D = sensor_out.size(-1)
+        if RF.batch_processor:
+            # -------- 构造批输入 --------
+            batch_in = sensor_out.expand(len(procs), -1)  # [N,D]
+
+            # -------- 共享一张网络 --------
+            net = procs[0].function
+
+            ctx = (torch.autocast("cuda", dtype=torch.float16)
+                   if (RF.use_fp16 and dev.type == "cuda") else nullcontext())
+            with ctx, torch.inference_mode():
+                batch_out = net(batch_in)                 # [N,D]
+
+            # -------- 回写 last_output --------
+            for u, o in zip(procs, batch_out):
+                u.last_output = o.detach()
+            merged = batch_out.mean(dim=0)
+        else:
+            # 回退：逐个 update
+            outs = []
+            for p in procs:
+                p.update(sensor_out)
+                outs.append(p.get_output().view(-1))
+            merged = torch.stack(outs).mean(dim=0)
+
+        # —— 与旧实现相同的 pad / truncate —— #
+        if merged.numel() < self.processor_hidden_size:
+            merged = torch.nn.functional.pad(
+                merged, (0, self.processor_hidden_size - merged.numel()))
+        else:
+            merged = merged[: self.processor_hidden_size]
+        return merged.to(dev)
+
+    def emitter_forward(self, proc_out: torch.Tensor):
+        """
+        批量版：把 for-loop --> 单次 repeat + Linear，逻辑不变
+        """
+        # ---- 0) 统一输入形状 ----
+        if proc_out.dim() == 1:
+            proc_out = proc_out.unsqueeze(0)  # [1, H_p]
+
+        # ---- 1) 对齐到 emitter_hidden_size ----
+        vec = proc_out[0]
+        H_e = self.emitter_hidden_size
+        if vec.shape[0] < H_e:
+            vec = F.pad(vec, (0, H_e - vec.shape[0]))
+        elif vec.shape[0] > H_e:
+            vec = vec[:H_e]
+
+        # ---- 2) 收集 emitter 索引（一次性）----
+        em_idx = [i for i, u in enumerate(self.units) if u.role == "emitter"]
+        if not em_idx:  # 没有 emitter
+            return None
+
+        # 一次性把所有 emitter 线性层升维
+        for i in em_idx:
+            self.expand_unit_dim(self.units[i], H_e)
+
+        # ---- 3) 单次 forward ----
+        batch_in = vec.repeat(len(em_idx), 1)  # [N_emit, H_e]
+        logits = self.emitter_net(batch_in)  # [N_emit, seq_len]
+
+        # ---- 4) 写回各 emitter.last_output ----
+        for idx, lg in zip(em_idx, logits):
+            self.units[idx].last_output = lg.detach()
+
+        return logits
+
+    def collect_emitter_outputs(self):
+        """收集所有 emitter 输出并自动对齐到目标维度"""
+        aligned = []
+        for unit in self.units:
+            if unit.get_role() != "emitter":
+                continue
+
+            raw = unit.get_output().squeeze(0) if unit.get_output().dim() == 2 else unit.get_output()
+            vec = self._align_to_goal_dim(raw)
+
+            if vec.shape[-1] != self._goal_dim():
+                # 理论不会发生，安全检查
+                logger.warning(f"[警告] 对齐失败 {unit.id} 长度 {vec.shape[-1]}")
+                continue
+
+            aligned.append(vec.unsqueeze(0))
+
+        if aligned:
+            stacked = torch.cat(aligned, dim=0).to(self.device, non_blocking=True)      # [N, goal_dim]
+            logger.debug(
+                "[输出检查] Emitter 对齐后均值(前5) : %s",
+                stacked.mean(dim=0)[:5]
+            )
+
+            return stacked
+        else:
+            logger.debug("[输出检查] 当前没有活跃的 emitter 单元")
+            return None

--- a/cogunit/__init__.py
+++ b/cogunit/__init__.py
@@ -1,0 +1,5 @@
+"""CogUnit package exposing the main `CogUnit` class."""
+
+from .core import CogUnit
+
+__all__ = ["CogUnit"]

--- a/cogunit/core.py
+++ b/cogunit/core.py
@@ -1,0 +1,154 @@
+# cogunit.py
+import torch
+import uuid
+import random
+from env import logger
+from collections import deque
+import torch.nn as nn
+from collections import defaultdict
+from config_runtime import RF            # ★ 新增
+from contextlib import nullcontext       # ★ autocast fallback
+from meta_cognition import MetaCognition
+from memory_unit import MemoryBuffer
+
+from . import settings as unit_settings
+from .settings import (
+    ENABLE_MINI_LEARN,
+    FOLLOW_INPUT_DEVICE,
+    MAX_OUTPUT_DIM,
+    SPLIT_HI_ES_TABLE,
+    SPLIT_HI_P_TABLE,
+    TOL_FRAC_SPLIT,
+    ROLE_SPLIT_RULE,
+    get_hi_threshold,
+)
+
+
+from .device import DeviceMixin
+from .learning import LearningMixin
+from .lifecycle import LifecycleMixin
+from .memory import MemoryMixin
+
+class CogUnit(DeviceMixin, LearningMixin, LifecycleMixin, MemoryMixin):
+    MAX_OUTPUT_DIM = MAX_OUTPUT_DIM
+
+    @classmethod
+    def configure_max_output_dim(cls, value):
+        """Synchronize the max output dimension across all CogUnit components."""
+        unit_settings.MAX_OUTPUT_DIM = value
+        cls.MAX_OUTPUT_DIM = value
+
+    """
+    CogUnit 是 EvoCore 的最小认知单元：
+    - 拥有独立状态、能量、年龄
+    - 可进行状态更新（update）与输出
+    - 可判断是否分裂（should_split）与死亡（should_die）
+    - 可克隆生成新单元（clone）
+    """
+
+    def __init__(self, input_size=50, hidden_size=16, role="processor",env_size=5, id=None, **kwargs):
+        self.is_elite = False
+        self.local_memory_pool = []  # 每个单元的私有记忆池
+
+        # 基因表达，表示对不同功能的偏好
+        self.gene = {
+            "sensor_bias": random.uniform(0.5, 1.5),
+            "processor_bias": random.uniform(0.5, 1.5),
+            "emitter_bias": random.uniform(0.5, 1.5),
+            "mutation_rate": 0.01 # 每次复制有1%概率突变
+        }
+
+        self.death_by_aging = False
+        self.subsystem_id = None  # 初始没有子系统归属
+        self.output_history = []  # ✅ 用于记录近几次输出，评估是否行为单一
+        self.call_history = []  # 记录最近几步的调用次数
+        self.call_window = 5  # 窗口长度，过去 5 步
+        self.inactive_steps = 0
+        # 位置总在 [0, env_size) 范围内随机
+        self.env_size = env_size
+        self.position = (
+            random.randint(0, env_size - 1),
+            random.randint(0, env_size - 1),
+        )
+        self.output_history_tensor = torch.zeros((5, input_size), device="cpu")
+        self.output_history_ptr = 0
+        # self._rebuild_safe_positions()
+        self.state_memory = []  # 记忆队列
+        self.memory_limit = 5
+        self.memory_pool_limit = 50
+        self.role = role
+        self.cleared_positions = set()
+        self.uuid = uuid.uuid4()
+        self.id = id or str(uuid.uuid4())
+        self.int_id = self.uuid.int & 0xFFFFFFFF
+        self.energy = 1.0               # 初始能量
+        self.age = 0                    # 生存步数
+        self.input_size = input_size
+        self.hidden_size = hidden_size
+        self.avg_recent_calls = 0.0
+        # 认知状态向量
+        self.state = torch.zeros(hidden_size)
+        self.output_positions = deque(maxlen=10)
+        self.is_hazard_confirmed = False
+        # 元认知记录器
+        self.meta = MetaCognition(history_len=100)
+        self.personal_goal = None            # 当前内在目标 (x,y)
+        self.visit_counts = {}               # {(x,y): 次数}
+        self.intrinsic_reward = 0.1        # 达到内在目标奖励能量
+        # 微型前馈网络（输入维度 → 隐藏维度 → 回到输入维度）
+        self.intrinsic_cooldown = 0  # 冷却步数
+        self._last_intrinsic_step = -float("inf")
+
+        self.function = torch.nn.Sequential(
+            torch.nn.Linear(input_size, hidden_size),
+            torch.nn.ReLU(),
+            torch.nn.Linear(hidden_size, input_size)
+        )
+
+        self.last_output = torch.zeros(input_size)
+        # ---------- 加速格式 ---------- #
+        if RF.use_channels_last and torch.cuda.is_available():
+            self.function = self.function.to(memory_format=torch.channels_last)
+        if RF.use_fp16 and torch.cuda.is_available():
+            self.function = self.function.half()   # 权重转 FP16
+
+        if "mutation_rate" not in self.gene:
+            self.gene["mutation_rate"] = 0.05
+        self.device = torch.device("cpu")  # 默认跟随 CPU
+        self.last_action_rewarded = False
+        self.last_reward_step = 0  # 记录上次获得 env 奖励的 step
+        # ----- 资源点打转管控 -----
+        self.last_rewarded_target_idx = None   # 上一次领奖的资源索引
+        self.linger_steps             = 0      # 在同一目标附近逗留的帧数
+        self.latest_base_reward       = 0.0    # 上一次靠近时发的 base 奖励，用来扣回
+        self.is_permanent_explorer = False
+        self.visit_counts = defaultdict(int)
+        self.memory_buffer = MemoryBuffer(maxlen=200)
+
+
+
+    # ---------------- 新增 ----------------
+    # -------------------------------------
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/cogunit/device.py
+++ b/cogunit/device.py
@@ -1,0 +1,42 @@
+"""CogUnit mixin module generated from the legacy monolith."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .core import CogUnit
+
+import torch
+
+from . import settings as unit_settings
+
+
+class DeviceMixin:
+    def to(self, device):
+        """把内部权重 & 状态迁移到指定设备（cpu / cuda）"""
+        device = torch.device(device)
+        if device == getattr(self, "device", torch.device("cpu")):
+            return self  # 已在目标 device，直接返回
+        self.device = device
+        self.function.to(device)
+        self.state = self.state.to(device)
+        self.last_output = self.last_output.to(device)
+        # 若还有其他缓存张量，也一并 .to(device)
+        return self
+
+    def get_position(self):
+        return self.position
+
+    def get_output(self) -> torch.Tensor:
+        """返回给下游单元使用的输出 (shape=[1, input_size])"""
+        if unit_settings.MAX_OUTPUT_DIM is not None and self.last_output.numel() > unit_settings.MAX_OUTPUT_DIM:
+            return self.last_output[:unit_settings.MAX_OUTPUT_DIM]
+        return self.last_output
+
+    def get_role(self):
+        return self.role
+
+    def __str__(self):
+        x, y = self.position
+        return f"CogUnit<{self.id}> Role:{self.role} Pos:({x},{y}) Age:{self.age} Energy:{self.energy:.2f} Gene:{self.gene}"

--- a/cogunit/learning.py
+++ b/cogunit/learning.py
@@ -1,0 +1,75 @@
+"""CogUnit mixin module generated from the legacy monolith."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .core import CogUnit
+
+import random
+import torch
+
+from env import logger
+from meta_cognition import MetaCognition
+
+
+class LearningMixin:
+    def mini_learn(self, input_tensor, target_tensor, lr=0.001):
+        if input_tensor.dim() == 1:
+            input_tensor = input_tensor.unsqueeze(0)
+        if target_tensor.dim() == 1:
+            target_tensor = target_tensor.unsqueeze(0)
+
+        # Forward
+        output = self.function(input_tensor)
+
+        # Loss
+        loss = torch.nn.functional.mse_loss(output, target_tensor)
+
+        # Backward
+        self.function.zero_grad()
+        loss.backward()
+
+        # Manual parameter update
+        with torch.no_grad():
+            for param in self.function.parameters():
+                if param.grad is not None:
+                    param.copy_(param - lr * param.grad)
+
+
+        logger.debug(f"[Mini-Learn] {self.id} loss={loss.item():.4f} (lr={lr})")
+
+    def compute_self_reward(self, input_tensor, output_tensor):
+        """
+        简单 self-reward：如果输出能跟输入保持一致性，就获得小奖励
+        """
+        if input_tensor.shape != output_tensor.shape:
+            output_tensor = output_tensor[:, :input_tensor.shape[1]]  # 防止维度不同
+        error = torch.mean((input_tensor - output_tensor) ** 2)
+        reward = 0.01 * (self.input_size / 50) * (1.0 - error.item())  # error越小奖励越高
+        return max(reward, 0.0)  # 不让奖励为负数
+
+    def evaluate_self(self, min_rate=0.3):
+        """
+        检查最近表现，若低于 min_rate 返回 True 表示需要变异/调整。
+        """
+        rate = self.meta.recent_success_rate()
+        if rate is None:
+            return False
+        return rate < min_rate
+
+    def request_upgrade(self, target_role=None, reason=""):
+        """
+        元认知评估后触发：记录一次升级意图，
+        CogGraph 后续可以检测到并执行真正的变异/重构。
+        """
+        # 1) 清空 MetaCognition 历史
+        self.meta = MetaCognition(history_len=self.meta.reward_trace.maxlen)
+        # 2) 基因轻扰动
+        for k in ["sensor_bias", "processor_bias", "emitter_bias"]:
+            self.gene[k] += random.gauss(0, 0.05)
+        # 3) 网络参数加小噪声
+        for p in self.function.parameters():
+            p.data += torch.randn_like(p) * 0.01
+        logger.info(f"[Meta-升级] {self.id}, {self.role} 因“{reason}”触发自我进化，开始思考赛博人生，觉得自己又行了。新gene={self.gene}")

--- a/cogunit/lifecycle.py
+++ b/cogunit/lifecycle.py
@@ -1,204 +1,34 @@
-# cogunit.py
-import torch
-import uuid
+"""CogUnit mixin module generated from the legacy monolith."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .core import CogUnit
+
 import random
-from env import logger
-from collections import deque
-import torch.nn as nn
+from contextlib import nullcontext
 from collections import defaultdict
-from config_runtime import RF            # ★ 新增
-from contextlib import nullcontext       # ★ autocast fallback
-from meta_cognition import MetaCognition
-from memory_unit import MemoryBuffer
+
+import torch
+import torch.nn as nn
+
+from config_runtime import RF
+from env import logger
+
+from .settings import (
+    ENABLE_MINI_LEARN,
+    FOLLOW_INPUT_DEVICE,
+    ROLE_SPLIT_RULE,
+    SPLIT_HI_ES_TABLE,
+    SPLIT_HI_P_TABLE,
+    TOL_FRAC_SPLIT,
+    get_hi_threshold,
+)
 
 
-
-# ======== CogUnit 全局功能开关 ========
-ENABLE_MINI_LEARN = False  # ← 关闭自编码训练
-FOLLOW_INPUT_DEVICE = True  # ← 自动把内部张量跟随输入 device（GPU/CPU）
-# 如想完全手动控制迁移，改成 False 并仅用 .to() 方法。
-MAX_OUTPUT_DIM = None       # ← 若设为 int，则 get_output() 强截断
-# ====================================
-
-
-
-# === Split-Gate 动态阈值表===========================
-# 比例 k_es：Emitter <-> Sensor   ／  k_p： 相对 Processor/2
-SPLIT_HI_ES_TABLE = { 50: 1.30, 200: 1.20, 500: 1.12, float("inf"): 1.05 }
-SPLIT_HI_P_TABLE  = { 50: 1.20, 200: 1.15, 500: 1.08, float("inf"): 1.03 }
-
-TOL_FRAC_SPLIT = 0.05      # 至少差值 Δ≥ceil(total×5 %) （且 ≥1）
-# ===============================================================
-
-def _get_hi(table, total):
-    """按照总细胞数返回当前阶段的 hi 阈值"""
-    for lim, val in table.items():
-        if total < lim:
-            return val
-    return table[float("inf")]
-
-
-
-# ── 角色分裂最低能量阈值 以及 最低调用频率 ────────────
-ROLE_SPLIT_RULE = {
-    "sensor":    {"min_e": 0.9, "min_calls": 0},   # 轻量，几乎不限制调用频率
-    "processor": {"min_e": 0.9, "min_calls": 1},   # 中等
-    "emitter":   {"min_e": 0.6, "min_calls": 0},
-}
-# ----------------------------------------------------
-
-
-
-class CogUnit:
-    """
-    CogUnit 是 EvoCore 的最小认知单元：
-    - 拥有独立状态、能量、年龄
-    - 可进行状态更新（update）与输出
-    - 可判断是否分裂（should_split）与死亡（should_die）
-    - 可克隆生成新单元（clone）
-    """
-
-    def __init__(self, input_size=50, hidden_size=16, role="processor",env_size=5, id=None, **kwargs):
-        self.is_elite = False
-        self.local_memory_pool = []  # 每个单元的私有记忆池
-
-        # 基因表达，表示对不同功能的偏好
-        self.gene = {
-            "sensor_bias": random.uniform(0.5, 1.5),
-            "processor_bias": random.uniform(0.5, 1.5),
-            "emitter_bias": random.uniform(0.5, 1.5),
-            "mutation_rate": 0.01 # 每次复制有1%概率突变
-        }
-
-        self.death_by_aging = False
-        self.subsystem_id = None  # 初始没有子系统归属
-        self.output_history = []  # ✅ 用于记录近几次输出，评估是否行为单一
-        self.call_history = []  # 记录最近几步的调用次数
-        self.call_window = 5  # 窗口长度，过去 5 步
-        self.inactive_steps = 0
-        # 位置总在 [0, env_size) 范围内随机
-        self.env_size = env_size
-        self.position = (
-            random.randint(0, env_size - 1),
-            random.randint(0, env_size - 1),
-        )
-        self.output_history_tensor = torch.zeros((5, input_size), device="cpu")
-        self.output_history_ptr = 0
-        # self._rebuild_safe_positions()
-        self.state_memory = []  # 记忆队列
-        self.memory_limit = 5
-        self.memory_pool_limit = 50
-        self.role = role
-        self.cleared_positions = set()
-        self.uuid = uuid.uuid4()
-        self.id = id or str(uuid.uuid4())
-        self.int_id = self.uuid.int & 0xFFFFFFFF
-        self.energy = 1.0               # 初始能量
-        self.age = 0                    # 生存步数
-        self.input_size = input_size
-        self.hidden_size = hidden_size
-        self.avg_recent_calls = 0.0
-        # 认知状态向量
-        self.state = torch.zeros(hidden_size)
-        self.output_positions = deque(maxlen=10)
-        self.is_hazard_confirmed = False
-        # 元认知记录器
-        self.meta = MetaCognition(history_len=100)
-        self.personal_goal = None            # 当前内在目标 (x,y)
-        self.visit_counts = {}               # {(x,y): 次数}
-        self.intrinsic_reward = 0.1        # 达到内在目标奖励能量
-        # 微型前馈网络（输入维度 → 隐藏维度 → 回到输入维度）
-        self.intrinsic_cooldown = 0  # 冷却步数
-        self._last_intrinsic_step = -float("inf")
-
-        self.function = torch.nn.Sequential(
-            torch.nn.Linear(input_size, hidden_size),
-            torch.nn.ReLU(),
-            torch.nn.Linear(hidden_size, input_size)
-        )
-
-        self.last_output = torch.zeros(input_size)
-        # ---------- 加速格式 ---------- #
-        if RF.use_channels_last and torch.cuda.is_available():
-            self.function = self.function.to(memory_format=torch.channels_last)
-        if RF.use_fp16 and torch.cuda.is_available():
-            self.function = self.function.half()   # 权重转 FP16
-
-        if "mutation_rate" not in self.gene:
-            self.gene["mutation_rate"] = 0.05
-        self.device = torch.device("cpu")  # 默认跟随 CPU
-        self.last_action_rewarded = False
-        self.last_reward_step = 0  # 记录上次获得 env 奖励的 step
-        # ----- 资源点打转管控 -----
-        self.last_rewarded_target_idx = None   # 上一次领奖的资源索引
-        self.linger_steps             = 0      # 在同一目标附近逗留的帧数
-        self.latest_base_reward       = 0.0    # 上一次靠近时发的 base 奖励，用来扣回
-        self.is_permanent_explorer = False
-        self.visit_counts = defaultdict(int)
-        self.memory_buffer = MemoryBuffer(maxlen=200)
-
-
-
-    # ---------------- 新增 ----------------
-    def to(self, device):
-        """把内部权重 & 状态迁移到指定设备（cpu / cuda）"""
-        device = torch.device(device)
-        if device == getattr(self, "device", torch.device("cpu")):
-            return self  # 已在目标 device，直接返回
-        self.device = device
-        self.function.to(device)
-        self.state = self.state.to(device)
-        self.last_output = self.last_output.to(device)
-        # 若还有其他缓存张量，也一并 .to(device)
-        return self
-    # -------------------------------------
-
-
-    def get_position(self):
-        return self.position
-
-    def mini_learn(self, input_tensor, target_tensor, lr=0.001):
-        if input_tensor.dim() == 1:
-            input_tensor = input_tensor.unsqueeze(0)
-        if target_tensor.dim() == 1:
-            target_tensor = target_tensor.unsqueeze(0)
-
-        # Forward
-        output = self.function(input_tensor)
-
-        # Loss
-        loss = torch.nn.functional.mse_loss(output, target_tensor)
-
-        # Backward
-        self.function.zero_grad()
-        loss.backward()
-
-        # Manual parameter update
-        with torch.no_grad():
-            for param in self.function.parameters():
-                if param.grad is not None:
-                    param.copy_(param - lr * param.grad)
-
-
-        logger.debug(f"[Mini-Learn] {self.id} loss={loss.item():.4f} (lr={lr})")
-
-
-    def compute_self_reward(self, input_tensor, output_tensor):
-        """
-        简单 self-reward：如果输出能跟输入保持一致性，就获得小奖励
-        """
-        if input_tensor.shape != output_tensor.shape:
-            output_tensor = output_tensor[:, :input_tensor.shape[1]]  # 防止维度不同
-        error = torch.mean((input_tensor - output_tensor) ** 2)
-        reward = 0.01 * (self.input_size / 50) * (1.0 - error.item())  # error越小奖励越高
-        return max(reward, 0.0)  # 不让奖励为负数
-
-    def get_recent_outputs(self, n=5):
-        """按时间顺序返回最近 n 帧输出（张量列表）"""
-        L = min(n, self.output_history_tensor.size(0))
-        idxs = [(self.output_history_ptr - i - 1) % L for i in reversed(range(L))]
-        return [self.output_history_tensor[i] for i in idxs]
-
+class LifecycleMixin:
     def update(self, input_tensor: torch.Tensor):
         input_tensor = input_tensor.squeeze()  # ← 保证不是 3 维
 
@@ -432,13 +262,6 @@ class CogUnit:
             if ENABLE_MINI_LEARN:
                 self.mini_learn(input_tensor, input_tensor, lr=lr)
 
-    def get_output(self) -> torch.Tensor:
-        """返回给下游单元使用的输出 (shape=[1, input_size])"""
-        if MAX_OUTPUT_DIM is not None and self.last_output.numel() > MAX_OUTPUT_DIM:
-            return self.last_output[:MAX_OUTPUT_DIM]
-        return self.last_output
-
-
     def should_split(self):
 
 
@@ -468,8 +291,8 @@ class CogUnit:
         # ===【Split-Gate : 1 : 2 : 1 动态门槛】===========================
         total = getattr(self, "global_unit_count", sensor_count + processor_count + emitter_count)
 
-        hi_es = _get_hi(SPLIT_HI_ES_TABLE, total)  # emitter <-> sensor
-        hi_p = _get_hi(SPLIT_HI_P_TABLE, total)  # 相对 processor/2
+        hi_es = get_hi_threshold(SPLIT_HI_ES_TABLE, total)  # emitter <-> sensor
+        hi_p = get_hi_threshold(SPLIT_HI_P_TABLE, total)  # 相对 processor/2
         half_p = processor_count / 2
 
         # 差值必须 ≥1 且 ≥ceil(total×TOL) 才算“真的多”
@@ -508,179 +331,6 @@ class CogUnit:
             return False
 
         return True
-
-    def evaluate_self(self, min_rate=0.3):
-        """
-        检查最近表现，若低于 min_rate 返回 True 表示需要变异/调整。
-        """
-        rate = self.meta.recent_success_rate()
-        if rate is None:
-            return False
-        return rate < min_rate
-
-    def request_upgrade(self, target_role=None, reason=""):
-        """
-        元认知评估后触发：记录一次升级意图，
-        CogGraph 后续可以检测到并执行真正的变异/重构。
-        """
-        # 1) 清空 MetaCognition 历史
-        self.meta = MetaCognition(history_len=self.meta.reward_trace.maxlen)
-        # 2) 基因轻扰动
-        for k in ["sensor_bias", "processor_bias", "emitter_bias"]:
-            self.gene[k] += random.gauss(0, 0.05)
-        # 3) 网络参数加小噪声
-        for p in self.function.parameters():
-            p.data += torch.randn_like(p) * 0.01
-        logger.info(f"[Meta-升级] {self.id}, {self.role} 因“{reason}”触发自我进化，开始思考赛博人生，觉得自己又行了。新gene={self.gene}")
-
-
-    def is_worthy_of_memory(self):
-        """根据不同角色，判断该细胞是否值得加入记忆池"""
-        if self.age < 100:
-            return False  # 太年轻的不记
-
-        if self.role == "sensor":
-            # 感知单元：至少要有两帧输出才能计算变化
-            if len(self.output_history) < 2:
-                return False
-
-            # 1) 计算 L1 变化量，先对齐到最小公共长度
-            changes = []
-            for prev, curr in zip(self.output_history, self.output_history[1:]):
-                p = prev.view(-1)
-                c = curr.view(-1)
-                L = min(p.numel(), c.numel())
-                changes.append((c[:L] - p[:L]).abs().sum().item())
-
-            if not changes:
-                return False
-
-            avg_change = sum(changes) / len(changes)
-            SENSOR_CHANGE_THRESHOLD = 5.0
-            return avg_change > SENSOR_CHANGE_THRESHOLD
-
-
-
-        elif self.role == "processor":
-            # 处理单元应关注调用频率 & 输出多样性
-            if getattr(self, "avg_recent_calls", 0) < 0.75:
-                return False
-            if len(self.output_history) < 2:
-                return False
-            total_diff = 0.0
-            count = 0
-            for prev, curr in zip(self.output_history, self.output_history[1:]):
-                # 只比较 shape 相同的
-                if prev.shape == curr.shape:
-                    total_diff += torch.norm(curr - prev).item()
-                    count += 1
-
-            if count == 0:
-                return False
-
-            variation = total_diff / count
-            return variation > 0.05  # 输出变化足够丰富
-
-
-        elif self.role == "emitter":
-            # 行为单元应关注任务完成情况和激活频率（活跃但非重复）
-            if self.avg_recent_calls < 2.0:
-                return False
-            if len(self.output_history) < 2:
-                return False
-            diff = sum(
-                torch.norm(self.output_history[i] - self.output_history[i + 1]).item()
-                for i in range(len(self.output_history) - 1)
-            ) / (len(self.output_history) - 1)
-            return 0.01 < diff < 0.5  # 太低代表退化，太高可能随机扰动
-
-
-        return False
-
-    def add_to_local_memory(self):
-        self.local_memory_pool = [m for m in self.local_memory_pool if "score" in m]
-        # —— 对齐 output_history 到同一长度 ——
-        import torch.nn.functional as F
-        aligned_history = None
-        if len(self.output_history) >= 3:
-            # 取最大元素数量
-            max_len = max(t.numel() for t in self.output_history)
-            aligned_history = []
-            for t in self.output_history:
-                vec = t.view(-1)  # 拉平
-                if vec.numel() < max_len:
-                    # 右侧补 0
-                    vec = F.pad(vec, (0, max_len - vec.numel()), value=0)
-                else:
-                    # 长则截断
-                    vec = vec[:max_len]
-                aligned_history.append(vec)
-
-        if self.role == "sensor":
-            if len(aligned_history) >= 2:
-                # 假设 output_history 至少有 2 帧
-                hist = [t.view(-1) for t in self.output_history]
-                diffs = []
-                for prev, curr in zip(self.output_history, self.output_history[1:]):
-                    p = prev.view(-1)
-                    c = curr.view(-1)
-                    L = min(p.numel(), c.numel())
-                    diffs.append((c[:L] - p[:L]).abs().sum().item())
-
-                variation = sum(diffs) / len(diffs)
-
-                score = variation
-            else:
-                score = 0
-
-        elif self.role == "processor":
-            # 处理：输出多样性 + 调用频率（已对齐）
-            if aligned_history:
-                diffs = [
-                    torch.norm(aligned_history[i] - aligned_history[i+1]).item()
-                    for i in range(len(aligned_history) - 1)
-                ]
-                diversity = sum(diffs) / len(diffs)
-            else:
-                diversity = 0
-            score = diversity * 0.5 + getattr(self, "avg_recent_calls", 0) * 0.3
-
-
-        elif self.role == "emitter":
-            # 输出：活跃性 + 输出稳定性（已对齐）
-            if aligned_history:
-                diffs = [
-                    torch.norm(aligned_history[i] - aligned_history[i+1]).item()
-                    for i in range(len(aligned_history) - 1)
-                ]
-                avg_diff = sum(diffs) / len(diffs)
-                stability = 1.0 if 0.01 < avg_diff < 0.5 else 0.0
-            else:
-                stability = 0
-            score = getattr(self, "avg_recent_calls", 0) * 0.5 + stability * 0.3
-
-
-        else:
-            score = self.energy + getattr(self, "avg_recent_calls", 0)
-
-        """将自身压缩为记忆格式，加入 local memory pool"""
-        mem = {
-            "gene": self.gene.copy(),
-            "output": self.last_output.clone(),
-            "role": self.role,
-            "age": self.age,
-            "hidden_size": self.hidden_size,
-            "score": score
-
-        }
-        self.local_memory_pool.append(mem)
-
-        # 控制最大记忆数量，移除最弱
-        if len(self.local_memory_pool) > self.memory_pool_limit:
-            self.local_memory_pool.sort(key=lambda m: m["score"])
-            self.local_memory_pool.pop(0)  # 移除最弱
-        logger.info(
-            f"[记忆加入] {self.id}（{self.role}，Age={self.age}）加入本地记忆池，评分={mem['score']:.2f}，当前共 {len(self.local_memory_pool)} 条")
 
     def should_die(self) -> bool:
         if self.role == "processor":
@@ -932,29 +582,3 @@ class CogUnit:
             clone_unit.visit_counts = self.visit_counts.copy()
 
         return clone_unit
-
-    def record_memory(self, state: torch.Tensor, action, reward: float, outcome: str):
-        """
-        外部在每步做完 reward 计算后调用：
-        state: 当时传入 update() 的输入张量（含 env+goal）
-        action: 本轮 emitter/processor 选的动作标识
-        reward: 本轮环境＋自我评价总 reward
-        outcome: 'success' or 'fail' or 自定义标签
-        """
-        self.memory_buffer.add(state, action, reward, outcome)
-
-    def recall(self, query_state: torch.Tensor, k: int = 5, metric: str = 'cosine'):
-        """
-        查历史经验，返回字典列表：
-        [{'state':…, 'action':…, 'reward':…, 'outcome':…}, …]
-        """
-        return self.memory_buffer.recall(query_state, k, metric)
-
-    def get_role(self):
-        return self.role
-
-    def __str__(self):
-        x, y = self.position
-        return f"CogUnit<{self.id}> Role:{self.role} Pos:({x},{y}) Age:{self.age} Energy:{self.energy:.2f} Gene:{self.gene}"
-
-

--- a/cogunit/memory.py
+++ b/cogunit/memory.py
@@ -1,0 +1,185 @@
+"""CogUnit mixin module generated from the legacy monolith."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .core import CogUnit
+
+import torch
+
+from env import logger
+
+
+class MemoryMixin:
+    def get_recent_outputs(self, n=5):
+        """按时间顺序返回最近 n 帧输出（张量列表）"""
+        L = min(n, self.output_history_tensor.size(0))
+        idxs = [(self.output_history_ptr - i - 1) % L for i in reversed(range(L))]
+        return [self.output_history_tensor[i] for i in idxs]
+
+    def is_worthy_of_memory(self):
+        """根据不同角色，判断该细胞是否值得加入记忆池"""
+        if self.age < 100:
+            return False  # 太年轻的不记
+
+        if self.role == "sensor":
+            # 感知单元：至少要有两帧输出才能计算变化
+            if len(self.output_history) < 2:
+                return False
+
+            # 1) 计算 L1 变化量，先对齐到最小公共长度
+            changes = []
+            for prev, curr in zip(self.output_history, self.output_history[1:]):
+                p = prev.view(-1)
+                c = curr.view(-1)
+                L = min(p.numel(), c.numel())
+                changes.append((c[:L] - p[:L]).abs().sum().item())
+
+            if not changes:
+                return False
+
+            avg_change = sum(changes) / len(changes)
+            SENSOR_CHANGE_THRESHOLD = 5.0
+            return avg_change > SENSOR_CHANGE_THRESHOLD
+
+
+
+        elif self.role == "processor":
+            # 处理单元应关注调用频率 & 输出多样性
+            if getattr(self, "avg_recent_calls", 0) < 0.75:
+                return False
+            if len(self.output_history) < 2:
+                return False
+            total_diff = 0.0
+            count = 0
+            for prev, curr in zip(self.output_history, self.output_history[1:]):
+                # 只比较 shape 相同的
+                if prev.shape == curr.shape:
+                    total_diff += torch.norm(curr - prev).item()
+                    count += 1
+
+            if count == 0:
+                return False
+
+            variation = total_diff / count
+            return variation > 0.05  # 输出变化足够丰富
+
+
+        elif self.role == "emitter":
+            # 行为单元应关注任务完成情况和激活频率（活跃但非重复）
+            if self.avg_recent_calls < 2.0:
+                return False
+            if len(self.output_history) < 2:
+                return False
+            diff = sum(
+                torch.norm(self.output_history[i] - self.output_history[i + 1]).item()
+                for i in range(len(self.output_history) - 1)
+            ) / (len(self.output_history) - 1)
+            return 0.01 < diff < 0.5  # 太低代表退化，太高可能随机扰动
+
+
+        return False
+
+    def add_to_local_memory(self):
+        self.local_memory_pool = [m for m in self.local_memory_pool if "score" in m]
+        # —— 对齐 output_history 到同一长度 ——
+        import torch.nn.functional as F
+        aligned_history = None
+        if len(self.output_history) >= 3:
+            # 取最大元素数量
+            max_len = max(t.numel() for t in self.output_history)
+            aligned_history = []
+            for t in self.output_history:
+                vec = t.view(-1)  # 拉平
+                if vec.numel() < max_len:
+                    # 右侧补 0
+                    vec = F.pad(vec, (0, max_len - vec.numel()), value=0)
+                else:
+                    # 长则截断
+                    vec = vec[:max_len]
+                aligned_history.append(vec)
+
+        if self.role == "sensor":
+            if len(aligned_history) >= 2:
+                # 假设 output_history 至少有 2 帧
+                hist = [t.view(-1) for t in self.output_history]
+                diffs = []
+                for prev, curr in zip(self.output_history, self.output_history[1:]):
+                    p = prev.view(-1)
+                    c = curr.view(-1)
+                    L = min(p.numel(), c.numel())
+                    diffs.append((c[:L] - p[:L]).abs().sum().item())
+
+                variation = sum(diffs) / len(diffs)
+
+                score = variation
+            else:
+                score = 0
+
+        elif self.role == "processor":
+            # 处理：输出多样性 + 调用频率（已对齐）
+            if aligned_history:
+                diffs = [
+                    torch.norm(aligned_history[i] - aligned_history[i+1]).item()
+                    for i in range(len(aligned_history) - 1)
+                ]
+                diversity = sum(diffs) / len(diffs)
+            else:
+                diversity = 0
+            score = diversity * 0.5 + getattr(self, "avg_recent_calls", 0) * 0.3
+
+
+        elif self.role == "emitter":
+            # 输出：活跃性 + 输出稳定性（已对齐）
+            if aligned_history:
+                diffs = [
+                    torch.norm(aligned_history[i] - aligned_history[i+1]).item()
+                    for i in range(len(aligned_history) - 1)
+                ]
+                avg_diff = sum(diffs) / len(diffs)
+                stability = 1.0 if 0.01 < avg_diff < 0.5 else 0.0
+            else:
+                stability = 0
+            score = getattr(self, "avg_recent_calls", 0) * 0.5 + stability * 0.3
+
+
+        else:
+            score = self.energy + getattr(self, "avg_recent_calls", 0)
+
+        """将自身压缩为记忆格式，加入 local memory pool"""
+        mem = {
+            "gene": self.gene.copy(),
+            "output": self.last_output.clone(),
+            "role": self.role,
+            "age": self.age,
+            "hidden_size": self.hidden_size,
+            "score": score
+
+        }
+        self.local_memory_pool.append(mem)
+
+        # 控制最大记忆数量，移除最弱
+        if len(self.local_memory_pool) > self.memory_pool_limit:
+            self.local_memory_pool.sort(key=lambda m: m["score"])
+            self.local_memory_pool.pop(0)  # 移除最弱
+        logger.info(
+            f"[记忆加入] {self.id}（{self.role}，Age={self.age}）加入本地记忆池，评分={mem['score']:.2f}，当前共 {len(self.local_memory_pool)} 条")
+
+    def record_memory(self, state: torch.Tensor, action, reward: float, outcome: str):
+        """
+        外部在每步做完 reward 计算后调用：
+        state: 当时传入 update() 的输入张量（含 env+goal）
+        action: 本轮 emitter/processor 选的动作标识
+        reward: 本轮环境＋自我评价总 reward
+        outcome: 'success' or 'fail' or 自定义标签
+        """
+        self.memory_buffer.add(state, action, reward, outcome)
+
+    def recall(self, query_state: torch.Tensor, k: int = 5, metric: str = 'cosine'):
+        """
+        查历史经验，返回字典列表：
+        [{'state':…, 'action':…, 'reward':…, 'outcome':…}, …]
+        """
+        return self.memory_buffer.recall(query_state, k, metric)

--- a/cogunit/settings.py
+++ b/cogunit/settings.py
@@ -1,0 +1,34 @@
+"""Configuration flags and thresholds for CogUnit behaviors."""
+
+ENABLE_MINI_LEARN = False  # ← 关闭自编码训练
+FOLLOW_INPUT_DEVICE = True  # ← 自动把内部张量跟随输入 device（GPU/CPU）
+MAX_OUTPUT_DIM = None       # ← 若设为 int，则 get_output() 强截断
+
+SPLIT_HI_ES_TABLE = {50: 1.30, 200: 1.20, 500: 1.12, float("inf"): 1.05}
+SPLIT_HI_P_TABLE = {50: 1.20, 200: 1.15, 500: 1.08, float("inf"): 1.03}
+TOL_FRAC_SPLIT = 0.05
+
+ROLE_SPLIT_RULE = {
+    "sensor": {"min_e": 0.9, "min_calls": 0},
+    "processor": {"min_e": 0.9, "min_calls": 1},
+    "emitter": {"min_e": 0.6, "min_calls": 0},
+}
+
+
+def get_hi_threshold(table: dict[int | float, float], total: int) -> float:
+    """按照总细胞数返回当前阶段的 hi 阈值"""
+    for limit, value in table.items():
+        if total < limit:
+            return value
+    return table[float("inf")]
+
+__all__ = [
+    "ENABLE_MINI_LEARN",
+    "FOLLOW_INPUT_DEVICE",
+    "MAX_OUTPUT_DIM",
+    "SPLIT_HI_ES_TABLE",
+    "SPLIT_HI_P_TABLE",
+    "TOL_FRAC_SPLIT",
+    "ROLE_SPLIT_RULE",
+    "get_hi_threshold",
+]

--- a/immune_cog_graph/__init__.py
+++ b/immune_cog_graph/__init__.py
@@ -1,0 +1,5 @@
+"""ImmuneCogGraph package exposing core interfaces."""
+
+from .core import ImmuneCogGraph
+
+__all__ = ["ImmuneCogGraph"]

--- a/immune_cog_graph/core.py
+++ b/immune_cog_graph/core.py
@@ -18,6 +18,7 @@ from adaptive_guidance import (
     ASSIGNMENT_SELF,
 )
 from config_runtime import RF
+from .forward import ForwardMixin
 from typing import List
 import random
 from per_memory import PrioritizedReplayBuffer
@@ -30,7 +31,7 @@ import torch.nn as nn
 from models.transformer_policy import TransformerPolicyNetwork
 from env import logger
 from torch.optim import AdamW
-from CogUnit import CogUnit
+from cogunit import CogUnit
 from sensor_module import SensorMLP
 
 
@@ -43,7 +44,7 @@ HIT_BONUS       = 1.0     # 命中立刻奖励
 MISS_PENALTY    = 0.00    # 打空扣分
 LEARNED_FACTOR  = 0.3     # learned assignment reward bias
 
-class ImmuneCogGraph(CogGraph):
+class ImmuneCogGraph(ForwardMixin, CogGraph):
     """
     最大化整合网络安全免疫系统：
     - 病毒环境：GridSecurityEnv
@@ -893,19 +894,6 @@ class ImmuneCogGraph(CogGraph):
         self.free_positions = [(int(xx), int(yy)) for xx, yy in zip(xs, ys)]
 
 
-    def sensor_forward(self, flat_state: torch.Tensor):
-        # 保证 [B, D_full]
-        if flat_state.dim() == 1:
-            flat_state = flat_state.unsqueeze(0)
-        D_full = self._D_env + self._D_hack + self._D_goal
-        L = flat_state.shape[1]
-        if L < D_full:
-            flat_state = F.pad(flat_state, (0, D_full - L))
-        elif L > D_full:
-            flat_state = flat_state[:, :D_full]
-
-        # 直接调用原始 sensor_net，不再使用 torch.compile
-        return self.sensor_net(flat_state)
 
 
     def _finalize_unit_update(
@@ -1106,98 +1094,7 @@ class ImmuneCogGraph(CogGraph):
         unit._last_intrinsic_step = self.current_step
         logger.info(f"[好奇点] 给 emitter {unit.id} 分配新好奇点：({tx},{ty})")
 
-    def processor_forward(self, sensor_out: torch.Tensor):
-        if sensor_out.dim() == 1:
-            sensor_out = sensor_out.unsqueeze(0)
 
-        # —— 共享网络模式 —— #
-        if self.use_shared_unit_nets:
-            if not hasattr(self, "_compiled_processor_net"):
-                try:
-                    self._compiled_processor_net = torch.compile(
-                        self.processor_net, fullgraph=False, dynamic=True
-                    )
-                except:
-                    self._compiled_processor_net = self.processor_net
-            out = self._compiled_processor_net(sensor_out)
-
-            # hotspot 合并
-            if not hasattr(self, "_hotspot_queue"):
-                self._hotspot_queue = deque(maxlen=20)
-            for p in (u for u in self.units if u.role == "processor"):
-                for pos in getattr(p, "hotspots", set()):
-                    if pos not in self._hotspot_queue:
-                        self._hotspot_queue.append(pos)
-                p.hotspots = set()
-            return out
-
-        # —— 独立网络模式 —— #
-        proc_units = [u for u in self.units if u.role == "processor"]
-        outs = []
-        for idx, u in enumerate(proc_units):
-            inp = sensor_out[idx:idx+1]
-            # 如果 u 没有自己的网络，就降级用全局的 self.processor_net
-            net = u.processor_net if hasattr(u, "processor_net") else self.processor_net
-            po  = net(inp)
-            outs.append(po)
-        proc_out = torch.cat(outs, dim=0) if outs else None
-
-        # hotspot 合并
-        if not hasattr(self, "_hotspot_queue"):
-            self._hotspot_queue = deque(maxlen=20)
-        for p in proc_units:
-            for pos in getattr(p, "hotspots", set()):
-                if pos not in self._hotspot_queue:
-                    self._hotspot_queue.append(pos)
-            p.hotspots = set()
-        return proc_out
-
-    def emitter_forward(self, proc_out: torch.Tensor):
-        """
-        支持「全局共享」或「各自网络」两种模式。
-        现在 proc_out → emitter_net → [batch, 3*seq_len]。
-        把 e.last_output 设置为长度 3*seq_len 的一维张量，供解码使用。
-        """
-        if proc_out.dim() == 1:
-            proc_out = proc_out.unsqueeze(0)
-
-        # 先对 vec 做对齐（pad/trunc）
-        vec = proc_out[0]
-        H_e = self.emitter_hidden_size
-        if vec.shape[0] < H_e:
-            vec = F.pad(vec, (0, H_e - vec.shape[0]))
-        elif vec.shape[0] > H_e:
-            vec = vec[:H_e]
-
-        emitters = [u for u in self.units if u.role == "emitter"]
-
-        # —— 共享 emitter_net —— #
-        if self.use_shared_unit_nets:
-            batch_in = []
-            for e in emitters:
-                self.expand_unit_dim(e, H_e)
-                batch_in.append(vec.unsqueeze(0))
-            if not batch_in:
-                return None
-            batch = torch.cat(batch_in, dim=0)  # [num_emitters, H_e]
-            logits = self.emitter_net(batch)  # [num_emitters, 3*seq_len]
-            for e, lg in zip(emitters, logits):
-                e.last_output = lg.detach()  # 一维 [3*seq_len]
-            return logits
-
-        # —— 独立 emitter_net —— #
-        logits_list = []
-        for e in emitters:
-            self.expand_unit_dim(e, H_e)
-            net = e.emitter_net if hasattr(e, "emitter_net") else self.emitter_net
-            lg = net(vec.unsqueeze(0))  # [1, 3*seq_len]
-            e.last_output = lg.detach().squeeze(0)  # [3*seq_len]
-            logits_list.append(lg)
-        if not logits_list:
-            return None
-
-        logits = torch.cat(logits_list, dim=0)  # [num_emitters, 3*seq_len]
-        return logits
 
     def expand_unit_dim(self, unit, new_in: int):
         """

--- a/immune_cog_graph/forward.py
+++ b/immune_cog_graph/forward.py
@@ -1,0 +1,122 @@
+"""Forward mixin for ImmuneCogGraph."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+import torch.nn.functional as F
+from collections import deque
+
+from env import logger
+
+if TYPE_CHECKING:
+    from .core import ImmuneCogGraph
+
+class ForwardMixin:
+    def sensor_forward(self, flat_state: torch.Tensor):
+        # 保证 [B, D_full]
+        if flat_state.dim() == 1:
+            flat_state = flat_state.unsqueeze(0)
+        D_full = self._D_env + self._D_hack + self._D_goal
+        L = flat_state.shape[1]
+        if L < D_full:
+            flat_state = F.pad(flat_state, (0, D_full - L))
+        elif L > D_full:
+            flat_state = flat_state[:, :D_full]
+
+        # 直接调用原始 sensor_net，不再使用 torch.compile
+        return self.sensor_net(flat_state)
+
+    def processor_forward(self, sensor_out: torch.Tensor):
+        if sensor_out.dim() == 1:
+            sensor_out = sensor_out.unsqueeze(0)
+
+        # —— 共享网络模式 —— #
+        if self.use_shared_unit_nets:
+            if not hasattr(self, "_compiled_processor_net"):
+                try:
+                    self._compiled_processor_net = torch.compile(
+                        self.processor_net, fullgraph=False, dynamic=True
+                    )
+                except:
+                    self._compiled_processor_net = self.processor_net
+            out = self._compiled_processor_net(sensor_out)
+
+            # hotspot 合并
+            if not hasattr(self, "_hotspot_queue"):
+                self._hotspot_queue = deque(maxlen=20)
+            for p in (u for u in self.units if u.role == "processor"):
+                for pos in getattr(p, "hotspots", set()):
+                    if pos not in self._hotspot_queue:
+                        self._hotspot_queue.append(pos)
+                p.hotspots = set()
+            return out
+
+        # —— 独立网络模式 —— #
+        proc_units = [u for u in self.units if u.role == "processor"]
+        outs = []
+        for idx, u in enumerate(proc_units):
+            inp = sensor_out[idx:idx+1]
+            # 如果 u 没有自己的网络，就降级用全局的 self.processor_net
+            net = u.processor_net if hasattr(u, "processor_net") else self.processor_net
+            po  = net(inp)
+            outs.append(po)
+        proc_out = torch.cat(outs, dim=0) if outs else None
+
+        # hotspot 合并
+        if not hasattr(self, "_hotspot_queue"):
+            self._hotspot_queue = deque(maxlen=20)
+        for p in proc_units:
+            for pos in getattr(p, "hotspots", set()):
+                if pos not in self._hotspot_queue:
+                    self._hotspot_queue.append(pos)
+            p.hotspots = set()
+        return proc_out
+
+    def emitter_forward(self, proc_out: torch.Tensor):
+        """
+        支持「全局共享」或「各自网络」两种模式。
+        现在 proc_out → emitter_net → [batch, 3*seq_len]。
+        把 e.last_output 设置为长度 3*seq_len 的一维张量，供解码使用。
+        """
+        if proc_out.dim() == 1:
+            proc_out = proc_out.unsqueeze(0)
+
+        # 先对 vec 做对齐（pad/trunc）
+        vec = proc_out[0]
+        H_e = self.emitter_hidden_size
+        if vec.shape[0] < H_e:
+            vec = F.pad(vec, (0, H_e - vec.shape[0]))
+        elif vec.shape[0] > H_e:
+            vec = vec[:H_e]
+
+        emitters = [u for u in self.units if u.role == "emitter"]
+
+        # —— 共享 emitter_net —— #
+        if self.use_shared_unit_nets:
+            batch_in = []
+            for e in emitters:
+                self.expand_unit_dim(e, H_e)
+                batch_in.append(vec.unsqueeze(0))
+            if not batch_in:
+                return None
+            batch = torch.cat(batch_in, dim=0)  # [num_emitters, H_e]
+            logits = self.emitter_net(batch)  # [num_emitters, 3*seq_len]
+            for e, lg in zip(emitters, logits):
+                e.last_output = lg.detach()  # 一维 [3*seq_len]
+            return logits
+
+        # —— 独立 emitter_net —— #
+        logits_list = []
+        for e in emitters:
+            self.expand_unit_dim(e, H_e)
+            net = e.emitter_net if hasattr(e, "emitter_net") else self.emitter_net
+            lg = net(vec.unsqueeze(0))  # [1, 3*seq_len]
+            e.last_output = lg.detach().squeeze(0)  # [3*seq_len]
+            logits_list.append(lg)
+        if not logits_list:
+            return None
+
+        logits = torch.cat(logits_list, dim=0)  # [num_emitters, 3*seq_len]
+        return logits

--- a/special_emitter.py
+++ b/special_emitter.py
@@ -1,6 +1,6 @@
 # special_emitter.py
 
-from CogUnit import CogUnit
+from cogunit import CogUnit
 from emitter_actions import EmitterActions
 from typing import Tuple, Dict, List
 

--- a/train_net_driven.py
+++ b/train_net_driven.py
@@ -15,7 +15,7 @@ import random
 from collections import deque
 
 from env_net import GridSecurityEnv
-from ImmuneCogGraph import ImmuneCogGraph
+from immune_cog_graph import ImmuneCogGraph
 from agents.rl_agent import RLAgent
 from contextlib import nullcontext
 

--- a/train_self_driven.py
+++ b/train_self_driven.py
@@ -18,6 +18,7 @@ import torch
 
 from env import GridEnvironment
 from coggraph import CogGraph          # 需确保已实现 forward 三接口
+from cogunit import CogUnit
 from agents.rl_agent import RLAgent
 from utils import IntrinsicCuriosityModule
 from collections import deque
@@ -122,8 +123,7 @@ def main(cfg):
     env = graph.env
 
     # ---- 新增 ----
-    import CogUnit
-    CogUnit.MAX_OUTPUT_DIM = graph.processor_hidden_size
+    CogUnit.configure_max_output_dim(graph.processor_hidden_size)
     # --------------------
 
     # 2) 动态推断 processor 输出维度 + 显式拼接目标向量后 rebuild Agent


### PR DESCRIPTION
## Summary
- split the legacy CogUnit implementation into a package composed of dedicated device, learning, lifecycle, and memory mixins with shared settings
- convert CogGraph and ImmuneCogGraph into importable packages and extract their forward-pass routines into mixins
- update special emitters and training scripts to consume the new package APIs and expose a helper for configuring max output dimensions

## Testing
- python -m compileall cogunit coggraph immune_cog_graph

------
https://chatgpt.com/codex/tasks/task_e_68e521e6da58832285e0b30bd581cc47