### PR TITLE
Refactor perception to hide resource identity

### DIFF
--- a/coggraph.py
+++ b/coggraph.py
@@ -22,14 +22,15 @@ except ImportError:
     HAS_TE = False
 import math
 from goal_generator import sample_unvisited, make_onehot
-from collections import Counter
 from self_model import build_self_model
 
 
 HIT_THRESH = 0.15          # 越大越宽松
 MAX_CONNECTIONS = 4  # 每个单元最多连接 4 个下游
-N_STATE_CHANNELS = 4
-N_GOAL_CHANNELS = 3
+# 状态通道：自身位置、未知事件点、访问痕迹
+N_STATE_CHANNELS = 3
+# 目标通道仅保留单一平面，供细胞自主学习使用
+N_GOAL_CHANNELS = 1
 INPUT_CHANNELS = N_STATE_CHANNELS + N_GOAL_CHANNELS
 
 
@@ -43,9 +44,8 @@ class TaskInjector:
     def encode_goal(self, env_size):
         """将目标位置编码成 one-hot 向量（与输入同维度）"""
         index = self.target_position[1] * env_size + self.target_position[0]
-        vec = torch.zeros(2, env_size * env_size)  # 2 通道
-        vec[0, index] = 1.0  # 资源层 one-hot
-        # vec[1] 先保持全 0（陷阱层以后再写）
+        vec = torch.zeros(1, env_size * env_size)  # 单通道，不区分资源/陷阱
+        vec[0, index] = 1.0
         return vec
 
     def evaluate(self, env, emitter_outputs):
@@ -177,7 +177,7 @@ class CogGraph:
         initial_target = (random.randint(0, self.env_size - 1), random.randint(0, self.env_size - 1))
         self.task = TaskInjector(target_position=initial_target)
         self.target_vector = self.task.encode_goal(self.env_size).to(self.device)
-        self.target_vector = torch.zeros((2, self.env_size * self.env_size), device=self.device)  # 初始化为空目标
+        self.target_vector = torch.zeros((1, self.env_size * self.env_size), device=self.device)  # 初始化为空目标
         self.max_total_energy = 500  # 初始最大总能量
         self.removed_hazards_by_reward = 0
         self.connection_usage = {}  # {(from_id, to_id): last_used_step}
@@ -189,7 +189,7 @@ class CogGraph:
         self.connections = {}  # {from_id: {to_id: strength_float}}
         self.unit_map = {}     # {unit_id: CogUnit 实例} 快速索引单元
         self.processor_hidden_size = self.env_size * self.env_size * INPUT_CHANNELS
-        self._target_buf = torch.zeros((2, self.env_size * self.env_size),
+        self._target_buf = torch.zeros((N_GOAL_CHANNELS, self.env_size * self.env_size),
                                        device=self.device)
         self.steps_since_last_reward = 0
         self.static_mode = False
@@ -1760,17 +1760,13 @@ class CogGraph:
         env_dim = self.env_size * self.env_size * N_STATE_CHANNELS
         batch = input_tensor
         env_state = batch[:, :env_dim]
-        res_map   = self.target_vector[0].unsqueeze(0)
-        hzd_map   = self.target_vector[1].unsqueeze(0)
-        full_state = torch.cat([env_state, torch.cat([res_map, hzd_map], dim=1)], dim=1)
+        goal_flat = self.target_vector.view(1, -1)
+        full_state = torch.cat([env_state, goal_flat], dim=1)
 
         # —— ⚙️ 静息模式下也要给 emitter 初始化 goal_vec —— #
         for u in self.units:
             if u.get_role() == "emitter":
-                ext = self.target_vector.clone()            # [2, env²]
-                int_zero = torch.zeros(1, self.env_size*self.env_size, device=self.device)
-                u.goal_vec = torch.cat([ext, int_zero], dim=0)
-                u.current_hazard_xy = getattr(self, "current_hazard_xy", None)
+                u.goal_vec = self.target_vector.clone()
 
         # upstream logic 重用 snapshot/prev_energies（如果需要 record_memory）
         state_snapshot = full_state.clone().squeeze(0).detach().to(self.device)
@@ -1834,12 +1830,9 @@ class CogGraph:
         env_dim  = self.env_size * self.env_size * N_STATE_CHANNELS
         env_state = batch[:, :env_dim]                    # (1, env_dim)
         # ---------- NEW: 把目标 one-hot 变成 2 个平面 ----------
-        res_map = self.target_vector[0].unsqueeze(0)  # (1, env²)  资源
-        hzd_map = self.target_vector[1].unsqueeze(0)  # (1, env²)  陷阱
-        goal_flat = torch.cat([res_map, hzd_map], dim=1)  # (1, 2·env²)
+        goal_flat = self.target_vector.view(1, -1)
 
-        # 6 通道打包
-        full_state = torch.cat([env_state, goal_flat], dim=1)  # (1, 6·env²)
+        full_state = torch.cat([env_state, goal_flat], dim=1)
         # ─── 新增：长期记忆准备 ───
         # 1) 把 state snapshot 存下来（去掉 batch 维）
         state_snapshot = full_state.clone().squeeze(0).detach().to(self.device)
@@ -2001,32 +1994,17 @@ class CogGraph:
             old_size = self.env_size
             self.env_size = self.env.size
             self.processor_hidden_size = self.env_size * self.env_size * INPUT_CHANNELS
-            full_state_dim = self.processor_hidden_size + 2 * (self.env_size * self.env_size)
+            full_state_dim = self.processor_hidden_size + N_GOAL_CHANNELS * (self.env_size * self.env_size)
             self.rl_agent.resize_state_dim(full_state_dim)
-            self._target_buf = self._target_buf.new_zeros((2, self.env_size * self.env_size))
+            self._target_buf = self._target_buf.new_zeros((N_GOAL_CHANNELS, self.env_size * self.env_size))
             if RF.use_shared_tx:
                 self._init_shared_tx()
             logger.info(f"[Env Resize] {old_size}→{self.env_size}, synced CogGraph dims")
 
     def _update_target_vector(self):
-        agent_pos = tuple(self.env.agent_pos)
-        nearest_res = self.env.get_nearest_resource_to(agent_pos)
-        nearest_hzd = self.env.get_nearest_danger_to(agent_pos)
-
-        target_xy = nearest_res
-        self.current_hazard_xy = nearest_hzd
-
         target_vec = self._target_buf
         target_vec.zero_()
-
-        if target_xy is not None:
-            idx = target_xy[1] * self.env_size + target_xy[0]
-            target_vec[0, idx] = 1.0
-
-        if nearest_hzd is not None:
-            hidx = nearest_hzd[1] * self.env_size + nearest_hzd[0]
-            target_vec[1, hidx] = 1.0
-
+        self.current_hazard_xy = None
         self.target_vector = target_vec
 
 
@@ -2035,49 +2013,8 @@ class CogGraph:
             self.expand_unit_dim(unit, expected_input)
 
         if unit.get_role() == "emitter":
-            # === 判断使用最近资源 / 陷阱 / 好奇点 ===
-            use_curiosity = getattr(unit, "is_permanent_explorer", False) and self.current_step >= 2000
-
-            if not use_curiosity:
-                pos = unit.get_position()
-                nearest_res = self.env.get_nearest_resource_to(pos)
-                nearest_hzd = self.env.get_nearest_danger_to(pos)
-
-                if nearest_res is not None:
-                    unit.personal_goal = nearest_res
-                    unit.goal_type = "resource"
-                elif nearest_hzd is not None:
-                    unit.personal_goal = nearest_hzd
-                    unit.goal_type = "hazard"
-                else:
-                    use_curiosity = True
-
-            if use_curiosity:
-                unit.goal_type = "curiosity"
-                taken = {
-                    e.personal_goal for e in self.units
-                    if e is not unit and e.get_role() == "emitter" and e.personal_goal is not None
-                }
-                unit.visit_counts = getattr(unit, "visit_counts", Counter())
-                unit.personal_goal = sample_unvisited(self.env_size, unit.visit_counts, exclude=taken)
-                unit.visit_counts.setdefault(unit.personal_goal, 0)
-
-            # === 构造目标向量 ===
-            res_map = torch.zeros(1, self.env_size * self.env_size, device=self.device)
-            hz_map = torch.zeros_like(res_map)
-            cu_map = torch.zeros_like(res_map)
-
-            if unit.personal_goal is not None:
-                idx = unit.personal_goal[1] * self.env_size + unit.personal_goal[0]
-                if unit.goal_type == "resource":
-                    res_map[0, idx] = 1.0
-                elif unit.goal_type == "hazard":
-                    hz_map[0, idx] = 1.0
-                elif unit.goal_type == "curiosity":
-                    cu_map[0, idx] = 1.0
-
-            unit.goal_vec = torch.cat([res_map, hz_map, cu_map], dim=0)
-            unit.current_hazard_xy = getattr(self, "current_hazard_xy", None)
+            if getattr(unit, "goal_vec", None) is None or unit.goal_vec.numel() != self.env_size * self.env_size * N_GOAL_CHANNELS:
+                unit.goal_vec = torch.zeros(N_GOAL_CHANNELS, self.env_size * self.env_size, device=self.device)
 
         unit.global_emitter_count = sum(1 for u in self.units if u.get_role() == "emitter")
         incoming = self.reverse_connections.get(unit.id, ())
@@ -2111,233 +2048,59 @@ class CogGraph:
             return torch.zeros(unit.input_size).unsqueeze(0)
 
     def reward_emitter_grid_environment(self):
-        decay_threshold = 40  # 超过 30 步未奖励就开始衰减
-        decay_amount = 0.04  # 每步扣能量
-        """基于 emitter 输出，在网格环境中执行资源 / 陷阱 奖励与惩罚逻辑。"""
+        """根据 emitter 的输出位置给出奖惩，不提供显式类别信息。"""
         outputs = self.collect_emitter_outputs()
         if outputs is None:
             return
 
-        action_indices = [torch.argmax(out).item() for out in outputs]
         emitters = [u for u in self.units if u.get_role() == "emitter"]
+        for unit, out in zip(emitters, outputs):
+            aligned = self._align_to_goal_dim(out)
+            if aligned.numel() == 0:
+                continue
 
-        for idx, unit in enumerate(emitters):
-            out = outputs[idx]
-            pred = torch.argmax(self._align_to_goal_dim(out)).item()
-            px, py = pred % self.env_size, pred // self.env_size
-            if (px, py) == unit.personal_goal:
-                unit.energy += unit.intrinsic_reward
-                unit.meta.record(action="intrinsic", reward=+unit.intrinsic_reward)
-                logger.info("你达到了你好奇的地方，心中充满了决心")
-                unit.visit_counts.setdefault((px, py), 0)
-                unit.visit_counts[(px, py)] += 1
-                if not getattr(unit, "is_permanent_explorer", False):
-                    unit._last_intrinsic_step = self.current_step
-                unit.personal_goal = None
-                if getattr(unit, "goal_vec", None) is not None \
-                        and unit.goal_vec.dim() == 2 \
-                        and unit.goal_vec.size(0) >= 3:
-                    unit.goal_vec[2].zero_()
+            pred_idx = torch.argmax(aligned).item()
+            px, py = pred_idx % self.env_size, pred_idx // self.env_size
 
-        for i, unit in enumerate(emitters):
-            out_vec = outputs[i]
-            pred = self._align_to_goal_dim(out_vec)
-            pred = torch.softmax(pred, dim=0)
+            unit.output_positions = getattr(unit, "output_positions", deque(maxlen=20))
+            unit.output_positions.append((px, py))
 
-            if unit.goal_vec.dim() == 2 and unit.goal_vec.size(0) >= 2:
-                # 用 personal_goal 而不是全局最近资源
-                if unit.personal_goal is not None:
-                    idx = unit.personal_goal[1] * self.env_size + unit.personal_goal[0]
-                    res_vec = torch.zeros_like(unit.goal_vec[0])
-                    res_vec[idx] = 1.0
-                else:
-                    res_vec = unit.goal_vec[0]
+            reward = 0.0
+            penalty = 0.0
 
-                hz_vec = unit.goal_vec[1]
-            else:
-                res_vec = unit.goal_vec.view(-1) if unit.goal_vec.dim() == 1 else unit.goal_vec[0]
-                hz_vec = torch.zeros_like(res_vec)
+            if (px, py) in self.env.resources and self.env.resources[(px, py)] > 0:
+                reward = 1.0
+                self.env.resources[(px, py)] -= 1
+                if self.env.resources[(px, py)] == 0:
+                    del self.env.resources[(px, py)]
+                self.removed_resources_count += 1
+                unit.last_reward_step = self.current_step
+                unit.last_action_rewarded = True
 
-            goal_vec = res_vec
-            res_dist = float((pred - res_vec).pow(2).mean().sqrt())
-            is_res_hit = res_dist < HIT_THRESH
-            is_res_near = HIT_THRESH <= res_dist <= 1.5
-            cur_idx = torch.argmax(res_vec).item()
-
-            hazard = getattr(unit, "current_hazard_xy", None)
-            if hazard is not None:
-                hx, hy = hazard
-                hazard_idx = hy * self.env_size + hx
-                pred_idx = torch.argmax(pred).item()
-                is_hz_hit = (pred_idx == hazard_idx)
-            else:
-                is_hz_hit = False
-
-            upstream_processors = [
-                self.unit_map[pid]
-                for pid in self.reverse_connections.get(unit.id, set())
-                if pid in self.unit_map and self.unit_map[pid].get_role() == "processor"
-            ]
-
-            # === 靠近陷阱后又撤退，触发好奇点切换 ===
-            if getattr(unit, "goal_type", "") == "hazard" and hazard is not None:
-                px, py = torch.argmax(pred).item() % self.env_size, torch.argmax(pred).item() // self.env_size
-                hz_dist = math.hypot(px - hx, py - hy)
-
-                prev_dist = getattr(unit, "_last_hazard_dist", float("inf"))
-                unit._last_hazard_dist = hz_dist  # 更新距离记录
-
-                if prev_dist <= 3.0 and hz_dist > 4.0:
-                    unit.goal_type = "curiosity"
-                    unit.personal_goal = sample_unvisited(self.env_size, unit.visit_counts)
-                    unit.visit_counts[unit.personal_goal] = 0
-                    logger.info(f"[目标切换] emitter {unit.id} 接近陷阱后撤退，发现不对劲，有歹徒要害我！ → 切换为好奇点 {unit.personal_goal}")
-
-            if is_hz_hit and (hx, hy) in self.env.hazards:
-                unit.energy -= 0.50
-                unit.meta.record(action=pred_idx, reward=-0.5)
-                for p in upstream_processors:
-                    p.energy -= 0.4
-                    p.meta.record(action=pred_idx, reward=-0.125)
-                unit.is_hazard_confirmed = True
-                unit.last_action_rewarded = False
-                if self.env.hazards[(hx, hy)] > 0:
-                    self.env.hazards[(hx, hy)] -= 1
-                    if self.env.hazards[(hx, hy)] == 0:
-                        del self.env.hazards[(hx, hy)]
+            if (px, py) in self.env.hazards and self.env.hazards[(px, py)] > 0:
+                penalty = 1.0
+                self.env.hazards[(px, py)] -= 1
+                if self.env.hazards[(px, py)] == 0:
+                    del self.env.hazards[(px, py)]
                 self.removed_hazards_count += 1
-                unit.goal_vec[1, hazard_idx] = 0.0
-                # —— 吃完这个资源之后，重新选最近的资源和惩罚点 —— #
-                if getattr(unit, "is_permanent_explorer", False):
-                    continue  # 永久探索者不应被重设为资源目标
+                unit.last_action_rewarded = False
 
-                next_res = self.env.get_nearest_resource_to(unit.get_position())
-                if next_res is not None:
-                    ridx = next_res[1] * self.env_size + next_res[0]
-                    unit.goal_vec[0].zero_()
-                    unit.goal_vec[0, ridx] = 1.0
-                next_hz = self.env.get_nearest_danger_to(unit.get_position())
-                if next_hz is not None:
-                    hidx = next_hz[1] * self.env_size + next_hz[0]
-                    unit.goal_vec[1].zero_()
-                    unit.goal_vec[1, hidx] = 1.0
+            net = reward - penalty
+            if net != 0.0:
+                unit.energy += net
+                unit.meta.record(action=pred_idx, reward=net)
+                unit.inactive_steps = 0
 
-                continue
-
-            hz_dist = float("inf")
-            if hazard is not None:
-                px, py = torch.argmax(pred).item() % self.env_size, torch.argmax(pred).item() // self.env_size
-                hz_dist = math.hypot(px - hx, py - hy)
-
-            if unit.is_hazard_confirmed and hz_dist > 3.0:
-                unit.energy += 0.04
-                unit.meta.record(action=pred_idx, reward=+0.04)
-                unit.is_hazard_confirmed = False
-                unit.last_reward_step = self.current_step
-                unit.last_action_rewarded = True
-
-            x_res, y_res = cur_idx % self.env_size, cur_idx // self.env_size
-            if (x_res, y_res) not in self.env.resources:
-                continue
-
-            if (unit.last_rewarded_target_idx != cur_idx) and (is_res_hit or is_res_near):
-                base_r = max(0.02 * (1.0 - res_dist), 0.0)
-                unit.energy += base_r
-                unit.meta.record(action=cur_idx, reward=+base_r)
-                for p in upstream_processors:
-                    p.energy += base_r * 0.25
-                    p.meta.record(action=cur_idx, reward=+(base_r * 0.25))
-
-                if is_res_hit:
-                    unit.energy += 1.2
-                    unit.meta.record(action=cur_idx, reward=+1.2)
-                    if self.env.resources[(x_res, y_res)] > 0:
-                        self.env.resources[(x_res, y_res)] -= 1
-                        if self.env.resources[(x_res, y_res)] == 0:
-                            del self.env.resources[(x_res, y_res)]
-                    self.removed_resources_count += 1
-                    # 2) 因资源奖励，额外删一个最远的坑
-                    if self.env.hazards:
-                        # 最远距离可以根据当前 (x_res,y_res) 算，也可以随意取
-                        far = max(
-                            self.env.hazards.keys(),
-                            key=lambda p: (p[0] - x_res) ** 2 + (p[1] - y_res) ** 2
-                        )
-                        del self.env.hazards[far]
-                        self.removed_hazards_by_reward += 1
-                    if getattr(unit, "is_permanent_explorer", False):
-                        continue  # 永久探索者不应被重设为资源目标
-
-                    # —— 吃完资源后，重新选最近的资源&惩罚点 —— #
-                    next_res = self.env.get_nearest_resource_to(unit.get_position())
-                    if next_res is not None:
-                        ridx = next_res[1] * self.env_size + next_res[0]
-                        unit.goal_vec[0].zero_()
-                        unit.goal_vec[0, ridx] = 1.0
-                    next_hz = self.env.get_nearest_danger_to(unit.get_position())
-                    if next_hz is not None:
-                        hidx = next_hz[1] * self.env_size + next_hz[0]
-                        unit.goal_vec[1].zero_()
-                        unit.goal_vec[1, hidx] = 1.0
-
-                    unit.last_rewarded_target_idx = None
-                    unit.linger_steps = 0
-                    unit.last_reward_amount = 0.0
-                    for p in upstream_processors:
-                        p.energy += 0.9
-                        p.meta.record(action="cur_idx", reward=+0.9)
-
-                unit.last_rewarded_target_idx = cur_idx
-                unit.last_reward_amount = base_r
-                unit.linger_steps = 0
-                unit.last_reward_step = self.current_step
-                unit.last_action_rewarded = True
-                continue
-
-            if (unit.last_rewarded_target_idx == cur_idx) and res_dist <= 2.0 and self.current_step >= 1500:
-                unit.linger_steps = min(unit.linger_steps + 1, 20)
-                if unit.linger_steps > 3:
-                    unit.energy -= 0.01
-                    unit.meta.record(action=cur_idx, reward=-0.01)
-                continue
-
-            if (unit.last_rewarded_target_idx == cur_idx) and res_dist > 4.0:
-                unit.energy -= unit.last_reward_amount
-                unit.meta.record(action=cur_idx, reward=-unit.last_reward_amount)
-                unit.last_rewarded_target_idx = None
-                unit.linger_steps = 0
-                unit.last_reward_amount = 0.0
-
-            if len(action_indices) >= 3:
-                most_common = max(set(action_indices), key=action_indices.count)
-                if action_indices.count(most_common) > len(action_indices) * 0.9:
-                    unit.energy -= 0.05
-                    unit.meta.record(action="diversity_penalty", reward=-0.05)
-                elif len(set(action_indices)) > len(action_indices) * 0.6:
-                    unit.energy += 0.05
-                    unit.meta.record(action="diversity_penalty", reward=+0.05)
-
-            if self.current_step > 1500:
-                inactive_steps = self.current_step - unit.last_reward_step
-                if inactive_steps > decay_threshold:
-                    unit.energy -= decay_amount * 0.1
-                    unit.meta.record(action="round", reward=-(decay_amount * 0.1))
-
-                if (hasattr(unit, "output_positions")
-                        and len(unit.output_positions) >= 10
-                        and self.current_step % 10 == 0):
-                    start = unit.output_positions[0]
-                    end = unit.output_positions[-1]
-                    manhattan = abs(start[0] - end[0]) + abs(start[1] - end[1])
-                    if 3 <= manhattan < 5:
-                        unit.energy -= 0.08
-                        unit.meta.record(action="move less", reward=-0.08)
-                    elif 6 <= manhattan < 8:
-                        unit.energy -= 0.10
-                        unit.meta.record(action="move less", reward=-0.1)
-                    elif 9 <= manhattan <= 10:
-                        unit.energy -= 0.12
-                        unit.meta.record(action="move less", reward=-0.12)
+                upstream_processors = [
+                    self.unit_map[pid]
+                    for pid in self.reverse_connections.get(unit.id, set())
+                    if pid in self.unit_map and self.unit_map[pid].get_role() == "processor"
+                ]
+                for proc in upstream_processors:
+                    proc.energy += net * 0.25
+                    proc.meta.record(action=pred_idx, reward=net * 0.25)
+            else:
+                unit.inactive_steps = getattr(unit, "inactive_steps", 0) + 1
 
 
     def _expand_environment_curriculum(self):
@@ -2347,7 +2110,7 @@ class CogGraph:
             self.env.resize(self.env_size)
 
             self.processor_hidden_size = self.env_size * self.env_size * INPUT_CHANNELS
-            full_dim = self.processor_hidden_size + self.env_size * self.env_size * 2
+            full_dim = self.processor_hidden_size + self.env_size * self.env_size * N_GOAL_CHANNELS
             self.rl_agent.resize_state_dim(full_dim)
 
             if RF.use_shared_tx:
@@ -2362,7 +2125,7 @@ class CogGraph:
 
             for u in self.units:
                 u.env_size = self.env_size
-            self._target_buf = self._target_buf.new_zeros((2, self.env_size * self.env_size))
+            self._target_buf = self._target_buf.new_zeros((N_GOAL_CHANNELS, self.env_size * self.env_size))
             for u in self.units:
                 u.memory_buffer.clear()
 
@@ -2384,10 +2147,8 @@ class CogGraph:
                 del pool[:half]
 
     def is_current_target_hazard(self) -> bool:
-        """判断当前目标是否是陷阱（指向陷阱的 one-hot）"""
-        index = torch.argmax(self.target_vector[1]).item()
-        x, y = index % self.env_size, index // self.env_size
-        return (x, y) in self.env.hazards
+        """单通道目标下默认视为未知类别。"""
+        return False
 
     def _align_to_goal_dim(self, tensor: torch.Tensor) -> torch.Tensor:
         """

--- a/env.py
+++ b/env.py
@@ -57,7 +57,8 @@ class GridEnvironment:
 
         # 初始化探索标记和状态缓冲
         self.visited_map = torch.zeros((self.size, self.size), dtype=torch.bool, device=self.device)
-        self._state_buf = torch.zeros((4, self.size, self.size), dtype=torch.float32, device=self.device)
+        # 状态通道：0=自身位置，1=未知类型的事件点（资源或危险），2=访问痕迹
+        self._state_buf = torch.zeros((3, self.size, self.size), dtype=torch.float32, device=self.device)
 
         # 初始化环境
         exclude = {tuple(self.agent_pos)}
@@ -96,10 +97,6 @@ class GridEnvironment:
         self.step_count = 0
         self.agent_energy_gain = 0.0
         self.agent_energy_penalty = 0.0
-
-        # 最近距离初始化
-        self.prev_dist_resource = self.distance_to_nearest_resource(tuple(self.agent_pos))
-        self.prev_danger_dist = self.distance_to_nearest_danger(tuple(self.agent_pos))
 
         # 清空标记
         self.visited_map.fill_(False)
@@ -143,20 +140,9 @@ class GridEnvironment:
         step_for_refresh = cog_step if cog_step is not None else self.step_count
         if step_for_refresh % 1000 == 0 and step_for_refresh >= 1000:
             self.refresh_environment(step_for_refresh, self.explored_cells_count)
-            self.prev_dist_resource = self.distance_to_nearest_resource(tuple(self.agent_pos))
-            self.prev_danger_dist = self.distance_to_nearest_danger(tuple(self.agent_pos))
 
-        # 计算 reward shaping
+        # 计算 reward（仅依赖实际能量变化和探索）
         base = self.agent_energy_gain - self.agent_energy_penalty
-        dist_res = self.distance_to_nearest_resource(pos)
-        delta_res = self.prev_dist_resource - dist_res
-        resource_shaping = 0.001 if delta_res > 0 else (-0.001 if delta_res < 0 else 0.0)
-        self.prev_dist_resource = dist_res
-
-        danger_dist = self.distance_to_nearest_danger(pos)
-        delta_danger = self.prev_danger_dist - danger_dist
-        danger_shaping = 0.001 if delta_danger > 0 else (-0.001 if delta_danger < 0 else 0.0)
-        self.prev_danger_dist = danger_dist
 
         explore_bonus = 0.0
         if not self.visited_map[y, x]:
@@ -164,7 +150,7 @@ class GridEnvironment:
             self.explored_cells_count += 1
             explore_bonus = 0.0001
 
-        reward = base + resource_shaping + danger_shaping + explore_bonus
+        reward = base + explore_bonus
         next_state = self.get_state()
 
         done = False
@@ -188,15 +174,15 @@ class GridEnvironment:
 
         x, y = self.agent_pos
         buf[0, y, x] = 1.0
-        for (rx, ry), cnt in self.resources.items():
-            # ← 边界检查，确保 0 <= rx,ry < size
-            if cnt > 0 and 0 <= rx < self.size and 0 <= ry < self.size:
-                buf[1, ry, rx] = 1.0
+        for (px, py), cnt in self.resources.items():
+            if cnt > 0 and 0 <= px < self.size and 0 <= py < self.size:
+                buf[1, py, px] = 1.0
 
-        for (hx, hy), cnt in self.hazards.items():
-            if cnt > 0 and 0 <= hx < self.size and 0 <= hy < self.size:
-                buf[2, hy, hx] = 1.0
-        buf[3].copy_(self.visited_map.to(torch.float32))
+        for (px, py), cnt in self.hazards.items():
+            if cnt > 0 and 0 <= px < self.size and 0 <= py < self.size:
+                buf[1, py, px] = 1.0
+
+        buf[2].copy_(self.visited_map.to(torch.float32))
 
         return buf.view(-1)
 
@@ -227,9 +213,9 @@ class GridEnvironment:
         self.visited_map = torch.zeros((new_size, new_size),
                                        dtype=torch.bool,
                                        device=self.device)
-        self._state_buf = torch.zeros((4, new_size, new_size),
-                                      dtype=torch.float32,
-                                      device=self.device)
+        self._state_buf = torch.zeros((3, new_size, new_size),
+                                       dtype=torch.float32,
+                                       device=self.device)
 
         x, y = self.agent_pos
         x = min(x, new_size - 1)
@@ -241,7 +227,7 @@ class GridEnvironment:
         self.size = new_size
         self.agent_pos = [np.random.randint(0, self.size), np.random.randint(0, self.size)]
         self.visited_map = torch.zeros((self.size, self.size), dtype=torch.bool, device=self.device)
-        self._state_buf = torch.zeros((4, self.size, self.size), dtype=torch.float32, device=self.device)
+        self._state_buf = torch.zeros((3, self.size, self.size), dtype=torch.float32, device=self.device)
         self.resources = Counter()
         self.hazards = Counter()
         self.step_count = 0

--- a/train_self_driven.py
+++ b/train_self_driven.py
@@ -25,7 +25,7 @@ import time
 import torch
 
 from env import GridEnvironment
-from coggraph import CogGraph          # 需确保已实现 forward 三接口
+from coggraph import CogGraph, N_GOAL_CHANNELS          # 需确保已实现 forward 三接口
 from agents.rl_agent import RLAgent
 from utils import IntrinsicCuriosityModule
 from collections import deque
@@ -137,7 +137,7 @@ def main(cfg):
     # 2) 动态推断 processor 输出维度 + 显式拼接目标向量后 rebuild Agent
     init_state = env.get_state().float()
     proc_dim = _infer_input_dim(graph, init_state)                   # e.g. 125
-    goal_dim = env.size * env.size * 2                               # 2 channels × env²
+    goal_dim = env.size * env.size * N_GOAL_CHANNELS
     full_dim = proc_dim + goal_dim                                   # e.g. 125+50=175
     agent = RLAgent(
         input_dim=full_dim,                                          # ← 用 full_dim
@@ -171,17 +171,12 @@ def main(cfg):
     state = env.get_state().float()
     # —— 新增：用滑动窗口保存最近 4 步的带目标向量的特征 —— #
     history = deque(maxlen=4)
-    # 构造一个固定长度 = proc_dim + 2*env² 的 init_feat
+    # 构造一个固定长度 = proc_dim + goal_dim 的 init_feat
     init_sensor    = graph.sensor_forward(state)                      # (1, state_dim)
     init_processor = graph.processor_forward(init_sensor).squeeze(0)  # (proc_dim,)
-    # —— 标准化目标向量到 2×(env²) —— #
     tv = graph.target_vector.to(device)
-    if tv.dim() == 1:
-        # 单通道→补第二通道全 0
-        tv = torch.stack([tv, torch.zeros_like(tv)], dim=0)          # (2, env²)
-    goal_vec = graph.target_vector.to(device).view(-1)  # 正好 2*env²
-    # (2*env²,)
-    init_feat = torch.cat([init_processor, goal_vec], dim=-1)       # (proc_dim+2*env²,)
+    goal_vec = tv.view(-1)
+    init_feat = torch.cat([init_processor, goal_vec], dim=-1)
     # --- 保守起见：若将来 proc_dim 变小，也对 init_feat 右补零 ---
     if init_feat.numel() < last_dim:  # last_dim 之前已经设为 full_dim
         init_feat = F.pad(init_feat, (0, last_dim - init_feat.numel()))
@@ -211,7 +206,7 @@ def main(cfg):
 
         # 如果 processor_hidden_size 变化，则同时更新到 full_dim
         proc_dim = graph.processor_hidden_size
-        goal_dim = env.size * env.size * 2
+        goal_dim = env.size * env.size * N_GOAL_CHANNELS
         new_full = proc_dim + goal_dim
         if new_full != last_dim:
             print(f"[Resize Input] dim: {last_dim} → {new_full}")
@@ -224,10 +219,7 @@ def main(cfg):
             history = deque(maxlen=history.maxlen)
             init_sensor    = graph.sensor_forward(state)
             init_processor = graph.processor_forward(init_sensor).squeeze(0)
-            # 同样标准化目标向量到 2×(env²)
             tv = graph.target_vector.to(device)
-            if tv.dim() == 1:
-                tv = torch.stack([tv, torch.zeros_like(tv)], dim=0)
             goal_vec = tv.view(-1)
             init_feat = torch.cat([init_processor, goal_vec], dim=-1)
             if init_feat.numel() < last_dim:  # new_full 已经赋给 last_dim
@@ -243,12 +235,8 @@ def main(cfg):
         processor_out = graph.processor_forward(sensor_out)
         env.render()
 
-        # —— 新增：加上本轮最近目标（资源 or 陷阱）的位置编码 —— #
-        # flatten 到一维（2*env²） 或者你也可以只取资源通道 goal_vec = graph.target_vector[0]
-        # —— 更新历史 & 构造带目标的特征 —— #
+        # —— 新增：加上本轮目标向量（无类别提示）的位置编码 —— #
         tv = graph.target_vector.to(device)
-        if tv.dim() == 1:
-            tv = torch.stack([tv, torch.zeros_like(tv)], dim=0)
         goal_vec  = tv.view(-1)
         step_feat = torch.cat([processor_out.squeeze(0), goal_vec], dim=-1)
         if step_feat.numel() < last_dim:  # 防止 < last_dim
@@ -274,50 +262,21 @@ def main(cfg):
         action = agent.select_action(state_seq)
         # ——— 使用 capture 形式执行一步环境，获取 raw_reward ———
 
-        # —— ⑥ Reward shaping ——
-        agent_pos   = tuple(env.agent_pos)
-        resources = env.resources
-        if resources:
-            # 用与最近资源的距离代替固定目标点
-            dists = [abs(agent_pos[0] - r[0]) + abs(agent_pos[1] - r[1]) for r in resources]
-            min_res_dist = min(dists)
-            proximity_bonus = 0.01 if min_res_dist <= 2 else 0.0
-        else:
-            proximity_bonus = 0.0
-
-        danger_dist = env.distance_to_nearest_danger(agent_pos)
-        if danger_dist <= 2:
-            danger_shaping = -0.05
-        elif danger_dist >= 3:
-            danger_shaping = 0.0
-
-        # —— ⑦ 用 env.step(...) 返回的 reward（含 base、resource_shaping、danger_shaping、explore_bonus）———
-        #    同时拿到下一状态和 done 标志
+        # —— ⑥ 与环境交互，获取原始奖励 ——
         next_state_np, raw_reward, done, _ = env.step(action, cog_step=graph.current_step)
 
-        # —— ⑧ 组合最终外在奖励 —— #
-        # raw_reward 已包含：
-        #   env.agent_energy_gain - env.agent_energy_penalty
-        # + resource_shaping (±0.01)
-        # + danger_shaping   (±0.2)
-        # + explore_bonus    (首次访问格子 +0.005)
-        # 这里再加上你原来的 proximity_bonus
-        ext_reward = raw_reward + proximity_bonus + danger_shaping
-        # —— ⑨ 下一状态转张量 —— #
-        # —— ⑧ 组合最终外在奖励 ——
-        ext_reward = raw_reward + proximity_bonus + danger_shaping
-        # —— ⑨ 下一状态转张量 ——
+        # —— ⑦ 组合最终外在奖励 —— #
+        ext_reward = raw_reward
+        # —— ⑧ 下一状态转张量 ——
         next_raw = next_state_np.float().to(device)
 
         # —— ⑩ 计算 Intrinsic Curiosity Reward —— #
         # 1) 下一个 Processor 特征
         next_sensor = graph.sensor_forward(next_raw)  # (1, proc_dim)
         next_processor = graph.processor_forward(next_sensor)  # (1, proc_dim)
-        # 2) 下一个 Goal 向量（双通道）
+        # 2) 下一个 Goal 向量
         tv_next = graph.target_vector.to(device)
-        if tv_next.dim() == 1:
-            tv_next = torch.stack([tv_next, torch.zeros_like(tv_next)], dim=0)
-        goal_vec_next = tv_next.view(-1)  # (2*env²,)
+        goal_vec_next = tv_next.view(-1)
         # 3) 拼接成 full_dim 特征
         next_feat = torch.cat([next_processor.squeeze(0), goal_vec_next], dim=-1)
         if next_feat.numel() < last_dim:


### PR DESCRIPTION
## Summary
- Collapse environment observations to a single unknown-point channel and rely on actual energy changes for rewards.
- Remove scripted target selection and rewrite emitter reward handling so cells must learn from hidden-resource outcomes.
- Update the training driver to consume the new goal encoding and drop handcrafted shaping signals.

## Testing
- python -m compileall env.py coggraph.py train_self_driven.py

------
https://chatgpt.com/codex/tasks/task_e_68e570df79008322bb4097db24127dec