### PR TITLE
Remove direct goal hints from training pipeline

### DIFF
--- a/coggraph.py
+++ b/coggraph.py
@@ -5,7 +5,6 @@ import torch
 import random
 from env import GridEnvironment
 import torch.nn.functional as F
-import numpy as np
 import gc, torch
 from collections import deque, Counter
 from env import logger
@@ -1366,7 +1365,8 @@ class CogGraph:
         if not all_scores:
             return  # 若没有评分数据，则跳过
 
-        score_threshold = np.percentile(all_scores, 90)  # 取前 10% 的分数为门槛
+        scores_tensor = torch.tensor(all_scores, dtype=torch.float32, device=self.device)
+        score_threshold = torch.quantile(scores_tensor, 0.9).item()  # 取前 10% 的分数为门槛
         candidates = []
 
         for u in self.units:
@@ -1760,9 +1760,13 @@ class CogGraph:
         env_dim = self.env_size * self.env_size * N_STATE_CHANNELS
         batch = input_tensor
         env_state = batch[:, :env_dim]
-        res_map   = self.target_vector[0].unsqueeze(0)
-        hzd_map   = self.target_vector[1].unsqueeze(0)
-        full_state = torch.cat([env_state, torch.cat([res_map, hzd_map], dim=1)], dim=1)
+        extra_channels = max(INPUT_CHANNELS - N_STATE_CHANNELS, 0)
+        if extra_channels:
+            pad_len = self.env_size * self.env_size * extra_channels
+            zero_pad = env_state.new_zeros((1, pad_len))
+            full_state = torch.cat([env_state, zero_pad], dim=1)
+        else:
+            full_state = env_state
 
         # —— ⚙️ 静息模式下也要给 emitter 初始化 goal_vec —— #
         for u in self.units:
@@ -1834,12 +1838,13 @@ class CogGraph:
         env_dim  = self.env_size * self.env_size * N_STATE_CHANNELS
         env_state = batch[:, :env_dim]                    # (1, env_dim)
         # ---------- NEW: 把目标 one-hot 变成 2 个平面 ----------
-        res_map = self.target_vector[0].unsqueeze(0)  # (1, env²)  资源
-        hzd_map = self.target_vector[1].unsqueeze(0)  # (1, env²)  陷阱
-        goal_flat = torch.cat([res_map, hzd_map], dim=1)  # (1, 2·env²)
-
-        # 6 通道打包
-        full_state = torch.cat([env_state, goal_flat], dim=1)  # (1, 6·env²)
+        extra_channels = max(INPUT_CHANNELS - N_STATE_CHANNELS, 0)
+        if extra_channels:
+            pad_len = self.env_size * self.env_size * extra_channels
+            zero_pad = env_state.new_zeros((1, pad_len))
+            full_state = torch.cat([env_state, zero_pad], dim=1)
+        else:
+            full_state = env_state
         # ─── 新增：长期记忆准备 ───
         # 1) 把 state snapshot 存下来（去掉 batch 维）
         state_snapshot = full_state.clone().squeeze(0).detach().to(self.device)

--- a/env.py
+++ b/env.py
@@ -1,4 +1,3 @@
-import numpy as np
 import random
 import logging
 import torch
@@ -53,7 +52,7 @@ class GridEnvironment:
         # 计数和位置
         self.step_count = 0
         self.explored_cells_count = 0
-        self.agent_pos = [np.random.randint(0, self.size), np.random.randint(0, self.size)]
+        self.agent_pos = [random.randrange(self.size), random.randrange(self.size)]
 
         # 初始化探索标记和状态缓冲
         self.visited_map = torch.zeros((self.size, self.size), dtype=torch.bool, device=self.device)
@@ -92,7 +91,7 @@ class GridEnvironment:
 
     def reset(self):
         # 随机初始化 agent
-        self.agent_pos = [np.random.randint(0, self.size), np.random.randint(0, self.size)]
+        self.agent_pos = [random.randrange(self.size), random.randrange(self.size)]
         self.step_count = 0
         self.agent_energy_gain = 0.0
         self.agent_energy_penalty = 0.0
@@ -201,9 +200,9 @@ class GridEnvironment:
         return buf.view(-1)
 
     def render(self):
-        grid = np.full((self.size, self.size), '.', dtype=str)
+        grid = [['.' for _ in range(self.size)] for _ in range(self.size)]
         x, y = self.agent_pos
-        grid[y, x] = 'A'
+        grid[y][x] = 'A'
         logger.debug('\n' + '\n'.join(' '.join(row) for row in grid) + '\n')
 
     def distance_to_nearest_danger(self, pos):
@@ -239,7 +238,7 @@ class GridEnvironment:
 
     def reset_with_size(self, new_size: int):
         self.size = new_size
-        self.agent_pos = [np.random.randint(0, self.size), np.random.randint(0, self.size)]
+        self.agent_pos = [random.randrange(self.size), random.randrange(self.size)]
         self.visited_map = torch.zeros((self.size, self.size), dtype=torch.bool, device=self.device)
         self._state_buf = torch.zeros((4, self.size, self.size), dtype=torch.float32, device=self.device)
         self.resources = Counter()
@@ -262,7 +261,7 @@ if __name__ == "__main__":
     env = GridEnvironment(size=10)
     env.render()
     for _ in range(5):
-        action = np.random.choice(4)
+        action = random.randrange(4)
         env.step(action)
         env.render()
         print("State vector:", env.get_state())

--- a/eval_policy.py
+++ b/eval_policy.py
@@ -34,38 +34,35 @@ import random
 import statistics
 from collections import deque
 
-import numpy as np
 import torch
 from env import GridEnvironment
 from coggraph import CogGraph, INPUT_CHANNELS
 from agents.rl_agent import RLAgent
 
 
-def pad_or_trunc(state_np: np.ndarray, target_len: int) -> np.ndarray:
-    """Flatten a state array and pad or truncate to target length"""
-    flat = state_np.ravel()
-    cur = flat.shape[0]
+def pad_or_trunc(state_tensor: torch.Tensor, target_len: int) -> torch.Tensor:
+    """Flatten a state tensor and pad or truncate to target length"""
+    flat = state_tensor.view(-1)
+    cur = flat.numel()
     if cur < target_len:
-        return np.concatenate([flat, np.zeros(target_len - cur, dtype=flat.dtype)])
+        pad = flat.new_zeros(target_len - cur)
+        return torch.cat([flat, pad], dim=0)
     return flat[:target_len]
 
 
-def build_feature(raw_state: np.ndarray, graph: CogGraph, raw_dim: int, device: str, saved_input_dim: int):
+def build_feature(raw_state: torch.Tensor, graph: CogGraph, raw_dim: int, device: str, saved_input_dim: int):
     """
-    Construct the input feature by running sensor->processor and appending goal vector.
-    Truncate or pad to saved_input_dim.
+    Construct the input feature by running sensor->processor. 目标向量不再透明提供，
+    因此直接依赖传感器/处理器输出即可。Truncate 或 pad 到 saved_input_dim。
     """
     flat = pad_or_trunc(raw_state, raw_dim)
-    inp = torch.from_numpy(flat).float().view(1, -1).to(device)
+    inp = flat.float().view(1, -1).to(device)
     s_out = graph.sensor_forward(inp)
-    p_out = graph.processor_forward(s_out).squeeze(0)
+    p_out = graph.processor_forward(s_out)
+    if p_out.dim() > 1:
+        p_out = p_out.squeeze(0)
 
-    tv = graph.target_vector
-    if tv.dim() == 1:
-        tv = torch.stack([tv, torch.zeros_like(tv)], dim=0)
-    goal = tv.view(-1).to(device)
-
-    feat = torch.cat([p_out, goal], dim=-1)
+    feat = p_out
     if feat.numel() < saved_input_dim:
         feat = torch.nn.functional.pad(feat, (0, saved_input_dim - feat.numel()))
     else:
@@ -95,7 +92,6 @@ def evaluate(ckpt_path: str, episodes: int, max_steps: int, device: str, seed: i
     # set random seeds
     if seed is not None:
         random.seed(seed)
-        np.random.seed(seed)
         torch.manual_seed(seed)
 
     # initialize environment and graph
@@ -149,7 +145,7 @@ def evaluate(ckpt_path: str, episodes: int, max_steps: int, device: str, seed: i
 
             # step graph to update target_vector
             raw_state = env.get_state()
-            graph.step(torch.from_numpy(pad_or_trunc(raw_state, raw_dim)).float().view(1, -1).to(device))
+            graph.step(pad_or_trunc(raw_state, raw_dim).float().view(1, -1).to(device))
 
             # execute action in environment
             next_raw, _, _, _ = env.step(action, cog_step=graph.current_step)

--- a/train_self_driven.py
+++ b/train_self_driven.py
@@ -136,9 +136,8 @@ def main(cfg):
 
     # 2) 动态推断 processor 输出维度 + 显式拼接目标向量后 rebuild Agent
     init_state = env.get_state().float()
-    proc_dim = _infer_input_dim(graph, init_state)                   # e.g. 125
-    goal_dim = env.size * env.size * 2                               # 2 channels × env²
-    full_dim = proc_dim + goal_dim                                   # e.g. 125+50=175
+    proc_dim = _infer_input_dim(graph, init_state)                   # e.g. 175 (= env² × channels)
+    full_dim = proc_dim                                              # 由 processor 输出直接决定
     agent = RLAgent(
         input_dim=full_dim,                                          # ← 用 full_dim
         num_actions=4,
@@ -171,17 +170,12 @@ def main(cfg):
     state = env.get_state().float()
     # —— 新增：用滑动窗口保存最近 4 步的带目标向量的特征 —— #
     history = deque(maxlen=4)
-    # 构造一个固定长度 = proc_dim + 2*env² 的 init_feat
-    init_sensor    = graph.sensor_forward(state)                      # (1, state_dim)
-    init_processor = graph.processor_forward(init_sensor).squeeze(0)  # (proc_dim,)
-    # —— 标准化目标向量到 2×(env²) —— #
-    tv = graph.target_vector.to(device)
-    if tv.dim() == 1:
-        # 单通道→补第二通道全 0
-        tv = torch.stack([tv, torch.zeros_like(tv)], dim=0)          # (2, env²)
-    goal_vec = graph.target_vector.to(device).view(-1)  # 正好 2*env²
-    # (2*env²,)
-    init_feat = torch.cat([init_processor, goal_vec], dim=-1)       # (proc_dim+2*env²,)
+    # 构造一个固定长度 = processor 输出维度 的 init_feat
+    init_sensor    = graph.sensor_forward(state)
+    init_processor = graph.processor_forward(init_sensor)
+    if init_processor.dim() > 1:
+        init_processor = init_processor.squeeze(0)
+    init_feat = init_processor
     # --- 保守起见：若将来 proc_dim 变小，也对 init_feat 右补零 ---
     if init_feat.numel() < last_dim:  # last_dim 之前已经设为 full_dim
         init_feat = F.pad(init_feat, (0, last_dim - init_feat.numel()))
@@ -204,15 +198,13 @@ def main(cfg):
         logger.warning(f"\n==== Step {global_step} (within horizon step {step_in_horizon}) ====")
 
         # —— ② 构造 CogGraph.step() 的输入 ——
-        goal_vec = graph.task.encode_goal(graph.env.size).float().to(device)
         flat_state = state.view(-1)                                       # (env_size*env_size*C,)
         inp = state.view(1, -1).to(device)     # (1, D)
         graph.step(inp)
 
         # 如果 processor_hidden_size 变化，则同时更新到 full_dim
         proc_dim = graph.processor_hidden_size
-        goal_dim = env.size * env.size * 2
-        new_full = proc_dim + goal_dim
+        new_full = proc_dim
         if new_full != last_dim:
             print(f"[Resize Input] dim: {last_dim} → {new_full}")
             agent.resize_state_dim(new_full)
@@ -223,13 +215,10 @@ def main(cfg):
             # —— 隐藏维度变更时，重置 history —— #
             history = deque(maxlen=history.maxlen)
             init_sensor    = graph.sensor_forward(state)
-            init_processor = graph.processor_forward(init_sensor).squeeze(0)
-            # 同样标准化目标向量到 2×(env²)
-            tv = graph.target_vector.to(device)
-            if tv.dim() == 1:
-                tv = torch.stack([tv, torch.zeros_like(tv)], dim=0)
-            goal_vec = tv.view(-1)
-            init_feat = torch.cat([init_processor, goal_vec], dim=-1)
+            init_processor = graph.processor_forward(init_sensor)
+            if init_processor.dim() > 1:
+                init_processor = init_processor.squeeze(0)
+            init_feat = init_processor
             if init_feat.numel() < last_dim:  # new_full 已经赋给 last_dim
                 init_feat = F.pad(init_feat, (0, last_dim - init_feat.numel()))
             for _ in range(history.maxlen):
@@ -239,18 +228,13 @@ def main(cfg):
 
 
         # —— ④ 拿 Transformer 输入 ——
-        sensor_out    = graph.sensor_forward(state)      # (1, state_dim)
+        sensor_out    = graph.sensor_forward(state)
         processor_out = graph.processor_forward(sensor_out)
         env.render()
 
-        # —— 新增：加上本轮最近目标（资源 or 陷阱）的位置编码 —— #
-        # flatten 到一维（2*env²） 或者你也可以只取资源通道 goal_vec = graph.target_vector[0]
-        # —— 更新历史 & 构造带目标的特征 —— #
-        tv = graph.target_vector.to(device)
-        if tv.dim() == 1:
-            tv = torch.stack([tv, torch.zeros_like(tv)], dim=0)
-        goal_vec  = tv.view(-1)
-        step_feat = torch.cat([processor_out.squeeze(0), goal_vec], dim=-1)
+        step_feat = processor_out
+        if step_feat.dim() > 1:
+            step_feat = step_feat.squeeze(0)
         if step_feat.numel() < last_dim:  # 防止 < last_dim
             step_feat = F.pad(step_feat, (0, last_dim - step_feat.numel()))
 
@@ -311,15 +295,11 @@ def main(cfg):
 
         # —— ⑩ 计算 Intrinsic Curiosity Reward —— #
         # 1) 下一个 Processor 特征
-        next_sensor = graph.sensor_forward(next_raw)  # (1, proc_dim)
-        next_processor = graph.processor_forward(next_sensor)  # (1, proc_dim)
-        # 2) 下一个 Goal 向量（双通道）
-        tv_next = graph.target_vector.to(device)
-        if tv_next.dim() == 1:
-            tv_next = torch.stack([tv_next, torch.zeros_like(tv_next)], dim=0)
-        goal_vec_next = tv_next.view(-1)  # (2*env²,)
-        # 3) 拼接成 full_dim 特征
-        next_feat = torch.cat([next_processor.squeeze(0), goal_vec_next], dim=-1)
+        next_sensor = graph.sensor_forward(next_raw)
+        next_processor = graph.processor_forward(next_sensor)
+        next_feat = next_processor
+        if next_feat.dim() > 1:
+            next_feat = next_feat.squeeze(0)
         if next_feat.numel() < last_dim:
             next_feat = F.pad(next_feat, (0, last_dim - next_feat.numel()))
         # 4) 用 step_feat (上面已构造) 和 next_feat 计算 IC 奖励


### PR DESCRIPTION
## Summary
- stop concatenating explicit goal vectors into the RL inputs so cells must learn from sensed resource and hazard maps
- zero-pad CogGraph sensor inputs instead of exposing target vectors and replace numpy percentile usage with torch equivalents
- drop the numpy dependency in the environment and evaluation utilities by using Python randomness and torch tensors throughout

## Testing
- `python train_self_driven.py --episodes 3 --max-steps 1000 --save-every 1 --device cpu` *(fails: ModuleNotFoundError: No module named 'torch' because the runtime lacks the dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68e5797eca0c8322a4d420d463c4598f