### PR TITLE
Enable sensor-driven awareness of resources and hazards

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,19 +31,19 @@ EvoCore 并非传统意义的 AI 模型，而是一个具备 **生命周期、�
 
 ##  新版本重要变更一览
 
-1. **目标向量二通道化**
+1. **目标向量多通道融合**
 
    * `TaskInjector.encode_goal()` 现返回 **`(2, env²)`** 的 one‑hot：<br>  `vec[0]` = 资源层，`vec[1]` = 陷阱层。
-   * `INPUT_CHANNELS = 4 (state) + 2 (goal) = 6`，全链路已对齐。
+   * CogGraph 中会额外拼接好奇心目标，共形成 **5 (状态) + 3 (目标) = 8** 个输入通道。
    * `coggraph.step()` 顶部旧的 `goal_tensor = ...` 已删除，避免混淆。
 2. **共享 Transformer 头数自适应**
 
    * 通过 `math.gcd(embed_dim, RF.shared_tx_heads)` 计算可整除的 **最大公因数** 作为实际多头数。
    * 若请求的头数无法整除，则自动降到满足整除的最接近值，并给出 warning。
-   * 默认在 6 通道 \* env² 的 embed\_dim 下，往往得到 **2 头** —— 不是硬编码，而是 GCD 恰好为 2。
+   * 默认在 8 通道 \* env² 的 embed\_dim 下，往往得到 **2 头** —— 不是硬编码，而是 GCD 恰好为 2。
 3. **环境扩容内存占用说明**
 
-   * 每 1000 步触发一次 curriculum：`env_size += 5`，同时 **input\_size = env² × 6** 线性暴涨。
+   * 每 1000 步触发一次 curriculum：`env_size += 5`，同时 **input\_size = env² × 8** 线性暴涨。
    * 为保持“细胞不降维”，`upscale_old_units()` 会 **复制旧权重并 zero‑pad 新维度**，导致显存/内存瞬时增加。
    * 可通过调小 `max_total_energy` 或延长扩容间隔来减缓内存高峰。
 
@@ -173,19 +173,19 @@ It is an *organism‑like* agent equipped with **life‑cycle, structural evolut
 
 ##  What’s New
 
-1. **Two‑Channel Goal Map**
+1. **Goal Map with Curiosity Fusion**
 
    * `TaskInjector.encode_goal()` now returns **`(2, env²)` one‑hot**: channel‑0 resource, channel‑1 hazard.
-   * `INPUT_CHANNELS = 4 (state) + 2 (goal) = 6` everywhere.
+   * CogGraph appends a curiosity layer, yielding **5 (state) + 3 (goal) = 8** total channels.
    * Legacy `goal_tensor` var in `coggraph.step()` is gone.
 2. **Head‑count Auto‑Tuning** for shared Transformer
 
    * We pick the **greatest common divisor** between embed\_dim and the requested `RF.shared_tx_heads`.
    * If not divisible, we gracefully downgrade (with a warning).
-   * With 6·env² dims the gcd often equals **2**, hence the observed "2 heads" — it is *data‑driven*, not hard‑coded.
+   * With 8·env² dims the gcd often equals **2**, hence the observed "2 heads" — it is *data‑driven*, not hard‑coded.
 3. **Memory Spikes on Curriculum Expansions**
 
-   * Every 1000 steps the grid grows (+5), thus **input\_size = env² × 6** inflates quadratically.
+   * Every 1000 steps the grid grows (+5), thus **input\_size = env² × 8** inflates quadratically.
    * `upscale_old_units()` keeps all historic params via zero‑padding → sudden RAM/GPU peaks.
    * Mitigate by lowering `max_total_energy` or stretching the expansion interval.
 

--- a/coggraph.py
+++ b/coggraph.py
@@ -5,7 +5,6 @@ import torch
 import random
 from env import GridEnvironment
 import torch.nn.functional as F
-import numpy as np
 import gc, torch
 from collections import deque, Counter
 from env import logger
@@ -28,12 +27,27 @@ from self_model import build_self_model
 
 HIT_THRESH = 0.15          # 越大越宽松
 MAX_CONNECTIONS = 4  # 每个单元最多连接 4 个下游
-N_STATE_CHANNELS = 4
+N_STATE_CHANNELS = 5
 N_GOAL_CHANNELS = 3
 INPUT_CHANNELS = N_STATE_CHANNELS + N_GOAL_CHANNELS
 
 
 
+
+
+def _percentile(values, q):
+    """轻量级百分位计算，避免依赖 numpy。"""
+    if not values:
+        return 0.0
+    sorted_vals = sorted(values)
+    k = (len(sorted_vals) - 1) * (q / 100.0)
+    f = math.floor(k)
+    c = math.ceil(k)
+    if f == c:
+        return float(sorted_vals[int(k)])
+    lower = sorted_vals[f]
+    upper = sorted_vals[c]
+    return float(lower * (c - k) + upper * (k - f))
 
 
 class TaskInjector:
@@ -1366,7 +1380,7 @@ class CogGraph:
         if not all_scores:
             return  # 若没有评分数据，则跳过
 
-        score_threshold = np.percentile(all_scores, 90)  # 取前 10% 的分数为门槛
+        score_threshold = _percentile(all_scores, 90)  # 取前 10% 的分数为门槛
         candidates = []
 
         for u in self.units:
@@ -2010,8 +2024,8 @@ class CogGraph:
 
     def _update_target_vector(self):
         agent_pos = tuple(self.env.agent_pos)
-        nearest_res = self.env.get_nearest_resource_to(agent_pos)
-        nearest_hzd = self.env.get_nearest_danger_to(agent_pos)
+        nearest_res = self.env.get_nearest_known_resource(agent_pos)
+        nearest_hzd = self.env.get_nearest_known_danger(agent_pos)
 
         target_xy = nearest_res
         self.current_hazard_xy = nearest_hzd
@@ -2040,8 +2054,8 @@ class CogGraph:
 
             if not use_curiosity:
                 pos = unit.get_position()
-                nearest_res = self.env.get_nearest_resource_to(pos)
-                nearest_hzd = self.env.get_nearest_danger_to(pos)
+                nearest_res = self.env.get_nearest_known_resource(pos)
+                nearest_hzd = self.env.get_nearest_known_danger(pos)
 
                 if nearest_res is not None:
                     unit.personal_goal = nearest_res
@@ -2205,18 +2219,19 @@ class CogGraph:
                     self.env.hazards[(hx, hy)] -= 1
                     if self.env.hazards[(hx, hy)] == 0:
                         del self.env.hazards[(hx, hy)]
+                self.env.update_known_cell((hx, hy))
                 self.removed_hazards_count += 1
                 unit.goal_vec[1, hazard_idx] = 0.0
                 # —— 吃完这个资源之后，重新选最近的资源和惩罚点 —— #
                 if getattr(unit, "is_permanent_explorer", False):
                     continue  # 永久探索者不应被重设为资源目标
 
-                next_res = self.env.get_nearest_resource_to(unit.get_position())
+                next_res = self.env.get_nearest_known_resource(unit.get_position())
                 if next_res is not None:
                     ridx = next_res[1] * self.env_size + next_res[0]
                     unit.goal_vec[0].zero_()
                     unit.goal_vec[0, ridx] = 1.0
-                next_hz = self.env.get_nearest_danger_to(unit.get_position())
+                next_hz = self.env.get_nearest_known_danger(unit.get_position())
                 if next_hz is not None:
                     hidx = next_hz[1] * self.env_size + next_hz[0]
                     unit.goal_vec[1].zero_()
@@ -2255,6 +2270,7 @@ class CogGraph:
                         self.env.resources[(x_res, y_res)] -= 1
                         if self.env.resources[(x_res, y_res)] == 0:
                             del self.env.resources[(x_res, y_res)]
+                    self.env.update_known_cell((x_res, y_res))
                     self.removed_resources_count += 1
                     # 2) 因资源奖励，额外删一个最远的坑
                     if self.env.hazards:
@@ -2264,17 +2280,18 @@ class CogGraph:
                             key=lambda p: (p[0] - x_res) ** 2 + (p[1] - y_res) ** 2
                         )
                         del self.env.hazards[far]
+                        self.env.update_known_cell(far)
                         self.removed_hazards_by_reward += 1
                     if getattr(unit, "is_permanent_explorer", False):
                         continue  # 永久探索者不应被重设为资源目标
 
                     # —— 吃完资源后，重新选最近的资源&惩罚点 —— #
-                    next_res = self.env.get_nearest_resource_to(unit.get_position())
+                    next_res = self.env.get_nearest_known_resource(unit.get_position())
                     if next_res is not None:
                         ridx = next_res[1] * self.env_size + next_res[0]
                         unit.goal_vec[0].zero_()
                         unit.goal_vec[0, ridx] = 1.0
-                    next_hz = self.env.get_nearest_danger_to(unit.get_position())
+                    next_hz = self.env.get_nearest_known_danger(unit.get_position())
                     if next_hz is not None:
                         hidx = next_hz[1] * self.env_size + next_hz[0]
                         unit.goal_vec[1].zero_()

--- a/env.py
+++ b/env.py
@@ -1,4 +1,3 @@
-import numpy as np
 import random
 import logging
 import torch
@@ -41,10 +40,11 @@ logger.addHandler(console_handler)
 class GridEnvironment:
     action_space_n = 4  # 上/下/左/右
 
-    def __init__(self, size=5, max_steps: int | None = None):
+    def __init__(self, size=5, max_steps: int | None = None, sensor_range: int = 2):
         self.size = size
         self.max_steps = max_steps
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.sensor_range = max(0, sensor_range)
 
         # 经验点和危险点
         self.resources = Counter()
@@ -53,11 +53,10 @@ class GridEnvironment:
         # 计数和位置
         self.step_count = 0
         self.explored_cells_count = 0
-        self.agent_pos = [np.random.randint(0, self.size), np.random.randint(0, self.size)]
+        self.agent_pos = [random.randrange(self.size), random.randrange(self.size)]
 
         # 初始化探索标记和状态缓冲
-        self.visited_map = torch.zeros((self.size, self.size), dtype=torch.bool, device=self.device)
-        self._state_buf = torch.zeros((4, self.size, self.size), dtype=torch.float32, device=self.device)
+        self._init_buffers()
 
         # 初始化环境
         exclude = {tuple(self.agent_pos)}
@@ -66,6 +65,15 @@ class GridEnvironment:
 
         self.reward_hit_count = 0
         self.danger_hit_count = 0
+
+    def _init_buffers(self):
+        shape = (self.size, self.size)
+        self.visited_map = torch.zeros(shape, dtype=torch.bool, device=self.device)
+        self.known_map = torch.zeros(shape, dtype=torch.bool, device=self.device)
+        self.detected_resources_map = torch.zeros(shape, dtype=torch.bool, device=self.device)
+        self.detected_hazards_map = torch.zeros(shape, dtype=torch.bool, device=self.device)
+        self._state_buf = torch.zeros((5, self.size, self.size), dtype=torch.float32, device=self.device)
+        self.explored_cells_count = 0
 
     def refresh_environment(self, step: int, explored_cells_count: int, exclude_positions: set = None):
         exclude_positions = exclude_positions or set()
@@ -88,22 +96,98 @@ class GridEnvironment:
 
         # 清空探索标记
         self.visited_map.fill_(False)
+        self.known_map.fill_(False)
+        self.detected_resources_map.fill_(False)
+        self.detected_hazards_map.fill_(False)
         self.explored_cells_count = 0
+        self._sense_environment()
+        self.prev_dist_resource = self.distance_to_nearest_known_resource(tuple(self.agent_pos))
+        self.prev_danger_dist = self.distance_to_nearest_known_danger(tuple(self.agent_pos))
+
+    def _in_bounds(self, x: int, y: int) -> bool:
+        return 0 <= x < self.size and 0 <= y < self.size
+
+    def _sense_environment(self):
+        """更新感知范围内的资源 / 危险信息到探测图。"""
+        ax, ay = self.agent_pos
+        rng = self.sensor_range
+        for dx in range(-rng, rng + 1):
+            for dy in range(-rng, rng + 1):
+                nx, ny = ax + dx, ay + dy
+                if not self._in_bounds(nx, ny):
+                    continue
+                self.known_map[ny, nx] = True
+                self.detected_resources_map[ny, nx] = bool(self.resources[(nx, ny)] > 0)
+                self.detected_hazards_map[ny, nx] = bool(self.hazards[(nx, ny)] > 0)
+
+    def update_known_cell(self, pos: tuple[int, int]):
+        """当资源 / 危险状态变化时，刷新已知网格的感知记录。"""
+        x, y = pos
+        if not self._in_bounds(x, y):
+            return
+        if not self.known_map[y, x]:
+            return
+        self.detected_resources_map[y, x] = bool(self.resources[(x, y)] > 0)
+        self.detected_hazards_map[y, x] = bool(self.hazards[(x, y)] > 0)
+
+    def get_known_resource_positions(self) -> list[tuple[int, int]]:
+        mask = (self.detected_resources_map & self.known_map).nonzero(as_tuple=False)
+        if mask.numel() == 0:
+            return []
+        coords = mask.cpu().tolist()
+        return [(int(x), int(y)) for y, x in coords]
+
+    def get_known_hazard_positions(self) -> list[tuple[int, int]]:
+        mask = (self.detected_hazards_map & self.known_map).nonzero(as_tuple=False)
+        if mask.numel() == 0:
+            return []
+        coords = mask.cpu().tolist()
+        return [(int(x), int(y)) for y, x in coords]
+
+    def get_nearest_known_resource(self, pos: tuple[int, int]) -> tuple[int, int] | None:
+        known = self.get_known_resource_positions()
+        if not known:
+            return None
+        return min(known, key=lambda r: abs(r[0] - pos[0]) + abs(r[1] - pos[1]))
+
+    def get_nearest_known_danger(self, pos: tuple[int, int]) -> tuple[int, int] | None:
+        known = self.get_known_hazard_positions()
+        if not known:
+            return None
+        return min(known, key=lambda r: abs(r[0] - pos[0]) + abs(r[1] - pos[1]))
+
+    def distance_to_nearest_known_resource(self, pos):
+        nearest = self.get_nearest_known_resource(pos)
+        if nearest is None:
+            return float("inf")
+        return abs(pos[0] - nearest[0]) + abs(pos[1] - nearest[1])
+
+    def distance_to_nearest_known_danger(self, pos):
+        nearest = self.get_nearest_known_danger(pos)
+        if nearest is None:
+            return float("inf")
+        return abs(pos[0] - nearest[0]) + abs(pos[1] - nearest[1])
 
     def reset(self):
         # 随机初始化 agent
-        self.agent_pos = [np.random.randint(0, self.size), np.random.randint(0, self.size)]
+        self.agent_pos = [random.randrange(self.size), random.randrange(self.size)]
         self.step_count = 0
         self.agent_energy_gain = 0.0
         self.agent_energy_penalty = 0.0
 
-        # 最近距离初始化
-        self.prev_dist_resource = self.distance_to_nearest_resource(tuple(self.agent_pos))
-        self.prev_danger_dist = self.distance_to_nearest_danger(tuple(self.agent_pos))
-
         # 清空标记
         self.visited_map.fill_(False)
+        self.known_map.fill_(False)
+        self.detected_resources_map.fill_(False)
+        self.detected_hazards_map.fill_(False)
         self.explored_cells_count = 0
+
+        # 执行一次感知，初始化局部知识
+        self._sense_environment()
+
+        # 最近距离初始化（基于已感知的知识）
+        self.prev_dist_resource = self.distance_to_nearest_known_resource(tuple(self.agent_pos))
+        self.prev_danger_dist = self.distance_to_nearest_known_danger(tuple(self.agent_pos))
 
         # 清空命中统计
         self.reward_hit_count = 0
@@ -138,22 +222,25 @@ class GridEnvironment:
         else:
             self.agent_energy_penalty = 0.0
 
+        # 感知更新（移动后立即刷新可见区域）
+        self._sense_environment()
+
         # 更新步数
         self.step_count += 1
         step_for_refresh = cog_step if cog_step is not None else self.step_count
         if step_for_refresh % 1000 == 0 and step_for_refresh >= 1000:
             self.refresh_environment(step_for_refresh, self.explored_cells_count)
-            self.prev_dist_resource = self.distance_to_nearest_resource(tuple(self.agent_pos))
-            self.prev_danger_dist = self.distance_to_nearest_danger(tuple(self.agent_pos))
+            self.prev_dist_resource = self.distance_to_nearest_known_resource(tuple(self.agent_pos))
+            self.prev_danger_dist = self.distance_to_nearest_known_danger(tuple(self.agent_pos))
 
         # 计算 reward shaping
         base = self.agent_energy_gain - self.agent_energy_penalty
-        dist_res = self.distance_to_nearest_resource(pos)
+        dist_res = self.distance_to_nearest_known_resource(pos)
         delta_res = self.prev_dist_resource - dist_res
         resource_shaping = 0.001 if delta_res > 0 else (-0.001 if delta_res < 0 else 0.0)
         self.prev_dist_resource = dist_res
 
-        danger_dist = self.distance_to_nearest_danger(pos)
+        danger_dist = self.distance_to_nearest_known_danger(pos)
         delta_danger = self.prev_danger_dist - danger_dist
         danger_shaping = 0.001 if delta_danger > 0 else (-0.001 if delta_danger < 0 else 0.0)
         self.prev_danger_dist = danger_dist
@@ -188,22 +275,17 @@ class GridEnvironment:
 
         x, y = self.agent_pos
         buf[0, y, x] = 1.0
-        for (rx, ry), cnt in self.resources.items():
-            # ← 边界检查，确保 0 <= rx,ry < size
-            if cnt > 0 and 0 <= rx < self.size and 0 <= ry < self.size:
-                buf[1, ry, rx] = 1.0
-
-        for (hx, hy), cnt in self.hazards.items():
-            if cnt > 0 and 0 <= hx < self.size and 0 <= hy < self.size:
-                buf[2, hy, hx] = 1.0
-        buf[3].copy_(self.visited_map.to(torch.float32))
+        buf[1].copy_(self.detected_resources_map.to(buf.dtype))
+        buf[2].copy_(self.detected_hazards_map.to(buf.dtype))
+        buf[3].copy_(self.known_map.to(buf.dtype))
+        buf[4].copy_(self.visited_map.to(buf.dtype))
 
         return buf.view(-1)
 
     def render(self):
-        grid = np.full((self.size, self.size), '.', dtype=str)
+        grid = [['.' for _ in range(self.size)] for _ in range(self.size)]
         x, y = self.agent_pos
-        grid[y, x] = 'A'
+        grid[y][x] = 'A'
         logger.debug('\n' + '\n'.join(' '.join(row) for row in grid) + '\n')
 
     def distance_to_nearest_danger(self, pos):
@@ -223,13 +305,7 @@ class GridEnvironment:
 
     def resize(self, new_size: int):
         self.size = new_size
-        # 2. 重新分配 visited_map 和 状态缓冲，保证和新 size 匹配
-        self.visited_map = torch.zeros((new_size, new_size),
-                                       dtype=torch.bool,
-                                       device=self.device)
-        self._state_buf = torch.zeros((4, new_size, new_size),
-                                      dtype=torch.float32,
-                                      device=self.device)
+        self._init_buffers()
 
         x, y = self.agent_pos
         x = min(x, new_size - 1)
@@ -239,9 +315,8 @@ class GridEnvironment:
 
     def reset_with_size(self, new_size: int):
         self.size = new_size
-        self.agent_pos = [np.random.randint(0, self.size), np.random.randint(0, self.size)]
-        self.visited_map = torch.zeros((self.size, self.size), dtype=torch.bool, device=self.device)
-        self._state_buf = torch.zeros((4, self.size, self.size), dtype=torch.float32, device=self.device)
+        self.agent_pos = [random.randrange(self.size), random.randrange(self.size)]
+        self._init_buffers()
         self.resources = Counter()
         self.hazards = Counter()
         self.step_count = 0
@@ -253,16 +328,22 @@ class GridEnvironment:
     def inject_reward_map(self, reward_points: list[tuple[int,int]], punishment_points: list[tuple[int,int]]):
         self.resources = Counter(reward_points)
         self.hazards = Counter(punishment_points)
-        self.visited_map = torch.zeros((self.size, self.size), dtype=torch.bool, device=self.device)
+        self.visited_map.fill_(False)
+        self.known_map.fill_(False)
+        self.detected_resources_map.fill_(False)
+        self.detected_hazards_map.fill_(False)
         self.explored_cells_count = 0
         self.reward_hit_count = 0
         self.danger_hit_count = 0
+        self._sense_environment()
+        self.prev_dist_resource = self.distance_to_nearest_known_resource(tuple(self.agent_pos))
+        self.prev_danger_dist = self.distance_to_nearest_known_danger(tuple(self.agent_pos))
 
 if __name__ == "__main__":
     env = GridEnvironment(size=10)
     env.render()
     for _ in range(5):
-        action = np.random.choice(4)
+        action = random.randrange(4)
         env.step(action)
         env.render()
         print("State vector:", env.get_state())


### PR DESCRIPTION
## Summary
- teach the grid environment to track sensor-visible resources and hazards, expose them through dedicated state channels, and drop the numpy dependency
- update CogGraph to consume the sensed knowledge for goal selection, keep emitter memories in sync when cells clear tiles, and refresh percentile logic without numpy
- document the expanded state/goal channel configuration in the README

## Testing
- `python train_self_driven.py --episodes 3 --max-steps 1000 --save-every 1 --device cpu` *(fails: missing torch module in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5797eca0c8322a4d420d463c4598f