### PR TITLE
Fix advantage normalization warning and skip unnecessary renders

### DIFF
--- a/agents/rl_agent.py
+++ b/agents/rl_agent.py
@@ -173,7 +173,13 @@ class RLAgent:
 
         returns_tensor = torch.stack(returns).view(-1)
         advantages_tensor = torch.stack(advantages).view(-1)
-        advantages_tensor = (advantages_tensor - advantages_tensor.mean()) / (advantages_tensor.std() + 1e-8)
+
+        if advantages_tensor.numel() > 1:
+            advantages_tensor = (advantages_tensor - advantages_tensor.mean()) / (
+                advantages_tensor.std(unbiased=False) + 1e-8
+            )
+        else:
+            advantages_tensor = advantages_tensor - advantages_tensor.mean()
         return returns_tensor.detach(), advantages_tensor.detach()
 
     def finish_episode(self, last_state_seq: torch.Tensor | None = None):

--- a/env.py
+++ b/env.py
@@ -283,6 +283,9 @@ class GridEnvironment:
         return buf.view(-1)
 
     def render(self):
+        if not logger.isEnabledFor(logging.DEBUG):
+            return
+
         grid = [['.' for _ in range(self.size)] for _ in range(self.size)]
         x, y = self.agent_pos
         grid[y][x] = 'A'


### PR DESCRIPTION
## Summary
- guard advantage normalization against single-sample batches to avoid numerical warnings
- short-circuit environment rendering when debug logging is disabled to cut per-step overhead

## Testing
- python -m compileall agents/rl_agent.py env.py

------
https://chatgpt.com/codex/tasks/task_e_68e5e3509d1c8322bb65c53036b29642