### PR TITLE
Fix advantage normalization warning and skip debug render work

### DIFF
--- a/agents/rl_agent.py
+++ b/agents/rl_agent.py
@@ -173,7 +173,13 @@ class RLAgent:
 
         returns_tensor = torch.stack(returns).view(-1)
         advantages_tensor = torch.stack(advantages).view(-1)
-        advantages_tensor = (advantages_tensor - advantages_tensor.mean()) / (advantages_tensor.std() + 1e-8)
+
+        adv_mean = advantages_tensor.mean()
+        adv_std = advantages_tensor.std(unbiased=False)
+        if torch.isnan(adv_std) or adv_std < 1e-8:
+            advantages_tensor = advantages_tensor - adv_mean
+        else:
+            advantages_tensor = (advantages_tensor - adv_mean) / (adv_std + 1e-8)
         return returns_tensor.detach(), advantages_tensor.detach()
 
     def finish_episode(self, last_state_seq: torch.Tensor | None = None):

--- a/env.py
+++ b/env.py
@@ -283,6 +283,9 @@ class GridEnvironment:
         return buf.view(-1)
 
     def render(self):
+        if not logger.isEnabledFor(logging.DEBUG):
+            return
+
         grid = [['.' for _ in range(self.size)] for _ in range(self.size)]
         x, y = self.agent_pos
         grid[y][x] = 'A'


### PR DESCRIPTION
## Summary
- prevent division-by-zero in advantage normalization by using a safe standard deviation
- avoid constructing grid output when debug logging is disabled to cut render overhead

## Testing
- python -m compileall agents/rl_agent.py env.py

------
https://chatgpt.com/codex/tasks/task_e_68e5e3509d1c8322bb65c53036b29642