### PR TITLE
Refresh environment when resources depleted

### DIFF
--- a/coggraph.py
+++ b/coggraph.py
@@ -2338,11 +2338,12 @@ class CogGraph:
             is_res_near = HIT_THRESH <= res_dist <= 1.5
             cur_idx = torch.argmax(res_vec).item()
 
+            pred_idx = torch.argmax(pred).item()
+
             hazard = getattr(unit, "current_hazard_xy", None)
             if hazard is not None:
                 hx, hy = hazard
                 hazard_idx = hy * self.env_size + hx
-                pred_idx = torch.argmax(pred).item()
                 is_hz_hit = (pred_idx == hazard_idx)
             else:
                 is_hz_hit = False

--- a/env.py
+++ b/env.py
@@ -175,6 +175,15 @@ class GridEnvironment:
         self.agent_energy_gain = 0.0
         self.agent_energy_penalty = 0.0
 
+        # 当资源被完全采集后，下一轮需要重新刷新环境，避免 "horizon step"
+        # 在每一步都被立即截断
+        if not self.resources:
+            self.refresh_environment(
+                step=0,
+                explored_cells_count=0,
+                exclude_positions={tuple(self.agent_pos)},
+            )
+
         # 清空标记
         self.visited_map.fill_(False)
         self.known_map.fill_(False)


### PR DESCRIPTION
## Summary
- refresh the grid environment during reset when all resources have been harvested to prevent immediate horizon resets

## Testing
- python -m compileall env.py

------
https://chatgpt.com/codex/tasks/task_e_68e698108f7c832280f7323e9cec5924