### PR TITLE
Enforce static mode cadence and reseed depleted populations

### DIFF
--- a/CogUnit.py
+++ b/CogUnit.py
@@ -98,6 +98,9 @@ class CogUnit:
         self.input_size = input_size
         self.hidden_size = hidden_size
         self.avg_recent_calls = 0.0
+        # —— 分裂限制：Emitter 最多允许 3~6 次 ——
+        self.emitter_split_cap = random.randint(3, 6) if self.role == "emitter" else None
+        self.emitter_splits_done = 0
         # 认知状态向量
         self.state = torch.zeros(hidden_size)
         self.output_positions = deque(maxlen=10)
@@ -568,6 +571,15 @@ class CogUnit:
         total = getattr(self, "global_unit_count", 1)
 
         role = self.get_role()
+
+        if role == "emitter":
+            cap = getattr(self, "emitter_split_cap", None)
+            if cap is None:
+                cap = random.randint(3, 6)
+                self.emitter_split_cap = cap
+            done = getattr(self, "emitter_splits_done", 0)
+            if done >= cap:
+                return False
 
         # ✅ 各类细胞紧急增殖
         if role == "emitter" and emitter_count <= 8:

--- a/coggraph.py
+++ b/coggraph.py
@@ -209,6 +209,7 @@ class CogGraph:
         self.static_mode = False
         self._orig_metabolic = {}   # 存储进入静吸模式前的速率
         self.static_mode_allowed = False
+        self._static_mode_forbid_step = 0
         # —— 缓存最近一次各角色的原始输出，供拓扑加权聚合使用 ——
         self._last_sensor_outputs: Dict[uuid.UUID, torch.Tensor] = {}
         self._last_processor_outputs: Dict[uuid.UUID, torch.Tensor] = {}
@@ -1526,6 +1527,60 @@ class CogGraph:
                 logger.debug(
                     f"[能量转移] {unit.id} ({role}) 系统过载 → 存入能量池 {contribution:.2f}，保留 {unit.energy:.2f}")
 
+    def _target_energy_for_unit(self, unit: CogUnit) -> float:
+        bias = float(unit.gene.get(f"{unit.role}_bias", 1.0))
+        bias = min(max(bias, 0.3), 2.0)
+        base = 0.4 if unit.role != "processor" else 0.45
+        if unit.role == "emitter":
+            base += 0.05
+        return min(1.2, base + 0.18 * bias)
+
+    def _emitter_priority_score(self, unit: CogUnit) -> float:
+        recent = getattr(unit, "avg_recent_calls", 0.0)
+        success = 0.0
+        if hasattr(unit, "meta"):
+            rate = unit.meta.recent_success_rate()
+            if rate is not None:
+                success = rate
+        return 0.6 * recent + 0.25 * success + 0.15 * float(unit.energy)
+
+    def _rapid_emitter_refuel(self):
+        if self.current_step % 5 != 0:
+            return
+        if self.energy_pool <= 1e-6:
+            return
+
+        emitters = [u for u in self.units if u.role == "emitter"]
+        if not emitters:
+            return
+
+        emitters.sort(key=self._emitter_priority_score, reverse=True)
+        top_k = max(1, math.ceil(len(emitters) * 0.7))
+        selected = emitters[:top_k]
+
+        distributed = 0.0
+        for unit in selected:
+            target = max(self._target_energy_for_unit(unit), 0.85)
+            critical = max(0.5, target * 0.85)
+            current = float(unit.energy)
+            if current >= critical:
+                continue
+            gap = target - current
+            if gap <= 1e-6:
+                continue
+            share = min(gap, 0.2, self.energy_pool)
+            if share <= 1e-6:
+                break
+            unit.energy += share
+            self.energy_pool -= share
+            distributed += share
+            if self.energy_pool <= 1e-6:
+                break
+
+        if distributed > 1e-6:
+            logger.debug(
+                f"[Emitter补能] 第 {self.current_step} 步快速补充 {distributed:.3f} 能量，池余 {self.energy_pool:.2f}")
+
     def supply_energy_from_pool(self):
         """
         每一步都根据个体属性评估是否需要从能量池补给，避免统一撒网。
@@ -1540,17 +1595,9 @@ class CogGraph:
         total_cell_energy = self.total_energy()
         max_allowable = self.max_total_energy * 0.9
 
-        def _target_energy(unit: CogUnit) -> float:
-            bias = float(unit.gene.get(f"{unit.role}_bias", 1.0))
-            bias = min(max(bias, 0.3), 2.0)
-            base = 0.4 if unit.role != "processor" else 0.45
-            if unit.role == "emitter":
-                base += 0.05
-            return min(1.2, base + 0.18 * bias)
-
         deficits = []
         for unit in self.units:
-            target = _target_energy(unit)
+            target = self._target_energy_for_unit(unit)
             gap = target - float(unit.energy)
             if gap <= 0.0:
                 continue
@@ -1645,6 +1692,16 @@ class CogGraph:
             global_hazards=self.env.hazards,
             free_positions=self.free_positions
         )
+
+        if getattr(parent, "role", None) == "emitter":
+            cap = getattr(parent, "emitter_split_cap", None)
+            if cap is None:
+                cap = random.randint(3, 6)
+                parent.emitter_split_cap = cap
+            parent.emitter_splits_done = getattr(parent, "emitter_splits_done", 0) + 1
+            if parent.emitter_splits_done >= cap:
+                logger.debug(
+                    f"[分裂封顶] {parent.id} 达到 {parent.emitter_splits_done}/{cap} 次限制，后续将作为工作细胞")
 
         self.connect(parent, child)
         self.auto_connect()  # 让新单元主动寻找连接
@@ -1853,6 +1910,8 @@ class CogGraph:
 
     # —— 2) 判断是否进入静吸模式 —— #
     def _check_enter_static_mode(self):
+        if self.current_step == self._static_mode_forbid_step:
+            return
         if self.current_step >= 1000 and self.steps_since_last_reward >= 100 and not self.static_mode:
             self._enter_static_mode()
 
@@ -1978,9 +2037,20 @@ class CogGraph:
 
     def _perform_system_maintenance(self):
         self.supply_energy_from_pool()
+        self._rapid_emitter_refuel()
 
-        if self.debug and self.current_step % 40 == 0:
+        if self.current_step > 0 and self.current_step % 40 == 0:
             self.rebalance_cell_types()
+
+    def _ensure_minimum_population(self):
+        if self.units:
+            return
+        if self.static_mode:
+            self._exit_static_mode()
+        logger.warning("[紧急增殖] 细胞数量降为 0，触发紧急补种")
+        self._init_seed_units(n_sensor=6, n_processor=12, n_emitter=6, device=self.device)
+        self.steps_since_last_reward = 0
+        self._static_mode_forbid_step = self.current_step
 
 
     def step(self, input_tensor: torch.Tensor):
@@ -1993,6 +2063,11 @@ class CogGraph:
             self.active_units.clear()
 
         self.current_step += 1
+        if self.current_step % 1000 == 0:
+            self.steps_since_last_reward = 0
+            self._static_mode_forbid_step = self.current_step
+            if self.static_mode:
+                self._exit_static_mode()
         self._update_global_counts()
 
         # === Transformer 一网打尽 ===
@@ -2089,6 +2164,8 @@ class CogGraph:
 
         if self.current_step > 0 and self.current_step % 50 == 0:
             self.finalize_deaths()
+
+        self._ensure_minimum_population()
 
         self.auto_connect()
 

--- a/train_self_driven.py
+++ b/train_self_driven.py
@@ -92,6 +92,61 @@ def _infer_input_dim(graph: CogGraph, env_state: torch.Tensor) -> int:
     return env_state.numel()
 
 
+def _init_performance_metrics() -> dict:
+    return {
+        "resource_hits": 0,
+        "hazard_hits": 0,
+        "energy_gain": 0.0,
+        "energy_penalty": 0.0,
+    }
+
+
+def _update_performance_metrics(metrics: dict, *, gain: float, penalty: float) -> None:
+    metrics["energy_gain"] += float(gain)
+    metrics["energy_penalty"] += float(penalty)
+    if gain > 0:
+        metrics["resource_hits"] += 1
+    if penalty > 0:
+        metrics["hazard_hits"] += 1
+
+
+def _summarize_performance_metrics(metrics: dict) -> dict:
+    total_interactions = metrics["resource_hits"] + metrics["hazard_hits"]
+    accuracy = (
+        metrics["resource_hits"] / total_interactions
+        if total_interactions > 0 else 0.0
+    )
+
+    total_energy_flow = metrics["energy_gain"] + metrics["energy_penalty"]
+    net_energy = metrics["energy_gain"] - metrics["energy_penalty"]
+    energy_eff = (
+        net_energy / total_energy_flow
+        if total_energy_flow > 0 else 0.0
+    )
+
+    overall = 0.6 * accuracy + 0.4 * energy_eff
+
+    return {
+        "accuracy": accuracy,
+        "energy_efficiency": energy_eff,
+        "overall_score": overall,
+        "resource_hits": metrics["resource_hits"],
+        "hazard_hits": metrics["hazard_hits"],
+        "net_energy": net_energy,
+        "total_energy_gain": metrics["energy_gain"],
+        "total_energy_penalty": metrics["energy_penalty"],
+    }
+
+
+def _reset_performance_metrics(metrics: dict) -> None:
+    metrics.update(
+        resource_hits=0,
+        hazard_hits=0,
+        energy_gain=0.0,
+        energy_penalty=0.0,
+    )
+
+
 # -------------------------------------------------------------------------- #
 #                              训练主函数                                    #
 # -------------------------------------------------------------------------- #
@@ -205,6 +260,26 @@ def main(cfg):
     _reset_history(state, history, last_dim)
 
 
+    performance_metrics = _init_performance_metrics()
+    score_history: list[dict] = []
+
+    def _log_and_reset_performance(hid: int) -> dict:
+        summary = _summarize_performance_metrics(performance_metrics)
+        logger.info(
+            "[评分] Horizon %d: accuracy=%.3f, energy_eff=%.3f, overall=%.3f | hits R/H=%d/%d | net_energy=%.3f",
+            hid,
+            summary["accuracy"],
+            summary["energy_efficiency"],
+            summary["overall_score"],
+            summary["resource_hits"],
+            summary["hazard_hits"],
+            summary["net_energy"],
+        )
+        score_history.append(summary)
+        _reset_performance_metrics(performance_metrics)
+        return summary
+
+
 
 
     ep_reward = 0.0
@@ -278,6 +353,12 @@ def main(cfg):
         #    同时拿到下一状态和 done 标志
         next_state_np, raw_reward, done, _ = env.step(action, cog_step=graph.current_step)
 
+        _update_performance_metrics(
+            performance_metrics,
+            gain=env.agent_energy_gain,
+            penalty=env.agent_energy_penalty,
+        )
+
         # —— ⑧ 组合最终外在奖励 —— #
         # raw_reward 已包含：
         #   env.agent_energy_gain - env.agent_energy_penalty
@@ -332,6 +413,7 @@ def main(cfg):
             if cfg.use_curiosity:
                 icm.update_parameters()
             reward_history.append(ep_reward)
+            _log_and_reset_performance(horizon_id)
             step_in_horizon = 0
             ep_reward = 0.0
             if hasattr(graph, "reset_state"):
@@ -348,6 +430,7 @@ def main(cfg):
             if cfg.use_curiosity:
                 icm.update_parameters()
             reward_history.append(ep_reward)
+            _log_and_reset_performance(horizon_id)
             step_in_horizon = 0
             ep_reward = 0.0
             if hasattr(graph, "reset_state"):
@@ -374,9 +457,27 @@ def main(cfg):
         if cfg.use_curiosity:
             icm.update_parameters()
         reward_history.append(ep_reward)
+        _log_and_reset_performance(horizon_id)
 
     # —— 训练总结 & 最终保存 ——
     print(f"Training finished ✓  total horizons = {horizon_id}")
+    if score_history:
+        avg_accuracy = sum(item["accuracy"] for item in score_history) / len(score_history)
+        avg_eff = sum(item["energy_efficiency"] for item in score_history) / len(score_history)
+        avg_overall = sum(item["overall_score"] for item in score_history) / len(score_history)
+        total_hits = sum(item["resource_hits"] for item in score_history)
+        total_hazards = sum(item["hazard_hits"] for item in score_history)
+        net_energy_total = sum(item["net_energy"] for item in score_history)
+        print(
+            "[评分汇总] avg_accuracy={:.3f}, avg_energy_eff={:.3f}, avg_overall={:.3f}, total_hits={} (hazards={}), net_energy_total={:.3f}".format(
+                avg_accuracy,
+                avg_eff,
+                avg_overall,
+                total_hits,
+                total_hazards,
+                net_energy_total,
+            )
+        )
     os.makedirs("checkpoints", exist_ok=True)
     agent.save("checkpoints/agent_final.pth")
     print("Saved final model to checkpoints/agent_final.pth")
@@ -385,8 +486,8 @@ def main(cfg):
 # -------------------------------------------------------------------------- #
 if __name__ == "__main__":
     cfg = get_cfg()
-    main(cfg)
     t0 = time.time()
+    main(cfg)
     print(f"Total runtime: {time.time() - t0:.1f} s")
 
 """


### PR DESCRIPTION
## Summary
- prevent static mode from triggering on exact 1000-step boundaries by forcing an exit and resetting the no-reward counter
- automatically reseed a small batch of cells when the population hits zero and make differentiation run every 40 steps
- track the last static-mode-forbidden step to avoid immediately re-entering rest after the forced exit
- limit emitter cloning to a capped 3-6 split quota so mature emitters remain as workers once they exhaust their allowance
- add a 5-step high-frequency emitter refuel pass that prioritises the top performers when the energy pool has reserves

## Testing
- python -m compileall CogUnit.py coggraph.py

------
https://chatgpt.com/codex/tasks/task_e_68e6ad1bddd483228312fad79a7ae483