### PR TITLE
Refine energy economy calibration

### DIFF
--- a/CogUnit.py
+++ b/CogUnit.py
@@ -11,6 +11,10 @@ from contextlib import nullcontext       # ★ autocast fallback
 from meta_cognition import MetaCognition
 from memory_unit import MemoryBuffer
 from torch.nn.utils import clip_grad_norm_
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from energy_policy import EnergyPolicy
 
 
 
@@ -110,10 +114,11 @@ class CogUnit:
         # —— 新增 Intrinsic Goal 支持 ——
         self.personal_goal = None            # 当前内在目标 (x,y)
         self.visit_counts = {}               # {(x,y): 次数}
-        self.intrinsic_reward = 1.0         # 达到内在目标奖励能量
+        self.intrinsic_reward = 0.3         # 达到内在目标奖励能量
         # 微型前馈网络（输入维度 → 隐藏维度 → 回到输入维度）
         self.intrinsic_cooldown = 20  # 冷却步数
         self._last_intrinsic_step = -float("inf")
+        self.energy_policy: "EnergyPolicy | None" = None
 
         self.function = torch.nn.Sequential(
             torch.nn.Linear(input_size, hidden_size),
@@ -177,6 +182,12 @@ class CogUnit:
             self.function = self.function.to(memory_format=torch.channels_last)
         if RF.use_fp16 and torch.cuda.is_available():
             self.function = self.function.half()
+
+    def attach_energy_policy(self, policy: "EnergyPolicy | None") -> None:
+        """Attach (or detach) the shared energy policy."""
+        self.energy_policy = policy
+        if policy is not None:
+            self.intrinsic_reward = policy.intrinsic_completion_bonus()
 
     def _init_optimizer(self, lr=None):
         base = lr if lr is not None else getattr(self, "base_lr", 1e-3)
@@ -497,10 +508,17 @@ class CogUnit:
 
         # === 高频调用奖励机制 ===
         avg_recent_calls = getattr(self, "avg_recent_calls", 0.0)
-        if avg_recent_calls >= 4.0 and self.energy > 0.0:
-            self.energy += 0.05
-            # self.meta.record(action="high_freq", reward=+0.04)
-            logger.debug(f"[奖励] {self.id} 平均调用频率 {avg_recent_calls:.2f} → 能量 +0.04")
+        policy = getattr(self, "energy_policy", None)
+        bonus = 0.0
+        if policy is not None:
+            bonus = policy.high_frequency_bonus(avg_recent_calls)
+        elif avg_recent_calls >= 4.0:
+            bonus = 0.05
+        if bonus > 0.0 and self.energy > 0.0:
+            self.energy += bonus
+            logger.debug(
+                f"[奖励] {self.id} 平均调用频率 {avg_recent_calls:.2f} → 能量 +{bonus:.4f}"
+            )
 
         # === 输出扰动：模拟早期探索行为（前10步）===
         if hasattr(self, "current_step"):
@@ -514,11 +532,17 @@ class CogUnit:
                 logger.debug(f"[扰动] processor {self.id} 输出加入扰动")
 
         # === ✅ 内部奖励机制 Self-Reward ===
-        self_reward = self.compute_self_reward(input_tensor, self.last_output) * 0.03
-        self.energy += self_reward
-        # self.meta.record(action="self_reward", reward=self_reward)
-        if self_reward > 0:
-            logger.debug(f"[内部奖励] {self.id} 自评奖励 +{self_reward:.4f} 能量 (现有能量 {self.energy:.2f})")
+        raw_self_reward = self.compute_self_reward(input_tensor, self.last_output)
+        delta_energy = (
+            policy.scale_self_reward(raw_self_reward)
+            if policy is not None
+            else raw_self_reward * 0.03
+        )
+        if delta_energy > 0.0:
+            self.energy += delta_energy
+            logger.debug(
+                f"[内部奖励] {self.id} 自评奖励 +{delta_energy:.4f} 能量 (现有能量 {self.energy:.2f})"
+            )
 
         # === ✅ 局部微型学习
         # ---------- 新增【探测-判定-更新目标】----------

--- a/coggraph.py
+++ b/coggraph.py
@@ -23,6 +23,7 @@ import math
 from goal_generator import sample_unvisited, make_onehot
 from collections import Counter
 from self_model import build_self_model
+from energy_policy import EnergyPolicy
 
 
 HIT_THRESH = 0.15          # 越大越宽松
@@ -200,6 +201,7 @@ class CogGraph:
         self.removed_resources_count = 0
         self.removed_hazards_count = 0
         self.active_units = set()
+        self.energy_policy = EnergyPolicy()
         self.connections = {}  # {from_id: {to_id: strength_float}}
         self.unit_map = {}     # {unit_id: CogUnit 实例} 快速索引单元
         self.processor_hidden_size = self.env_size * self.env_size * INPUT_CHANNELS
@@ -388,6 +390,8 @@ class CogGraph:
         if unit.device != self.device:
             unit.to(self.device)
         unit.graph = self
+        if hasattr(unit, "attach_energy_policy"):
+            unit.attach_energy_policy(self.energy_policy)
         # 将单元加入图结构中
         self.units.append(unit)
         self.unit_map[unit.id] = unit
@@ -1288,10 +1292,13 @@ class CogGraph:
             logger.info("[进化] 子系统竞争机制已激活（Subsystem Competition）")
 
         # 🟡 预热补偿（前 500 步）
-        if self.current_step < 500:
+        warmup_bonus = self.energy_policy.warmup_bonus(self.current_step)
+        if warmup_bonus > 0.0:
             for unit in self.units:
-                unit.energy += 0.02
-                logger.debug(f"[预热补偿] {unit.id} 初始阶段获得能量 +0.02")
+                unit.energy += warmup_bonus
+                logger.debug(
+                    f"[预热补偿] {unit.id} 初始阶段获得能量 +{warmup_bonus:.3f}"
+                )
 
         # 🟠 能量税（每 10 步）
         if self.current_step > 200 and self.current_step % 100 == 0:
@@ -1660,16 +1667,18 @@ class CogGraph:
 
             return consumed
 
+        primary_cap, secondary_cap = self.energy_policy.pool_caps()
         cap_gap = max(0.0, max_allowable - total_cell_energy)
         primary_budget = min(self.energy_pool, cap_gap)
-        consumed_primary = distribute(primary_budget, cap=0.25)
+        consumed_primary = distribute(primary_budget, cap=primary_cap)
         self.energy_pool -= consumed_primary
 
         remaining_needy = [d for d in active_deficits if d["gap"] > 1e-6]
         consumed_secondary = 0.0
         if remaining_needy and self.energy_pool > 1e-6:
-            stability_budget = min(self.energy_pool, 0.05 * len(remaining_needy))
-            consumed_secondary = distribute(stability_budget, cap=0.1)
+            stability_factor = self.energy_policy.pool_stability_factor()
+            stability_budget = min(self.energy_pool, stability_factor * len(remaining_needy))
+            consumed_secondary = distribute(stability_budget, cap=secondary_cap)
             self.energy_pool -= consumed_secondary
 
         consumed_total = (pool_before - self.energy_pool)
@@ -1692,6 +1701,8 @@ class CogGraph:
             global_hazards=self.env.hazards,
             free_positions=self.free_positions
         )
+        if hasattr(child, "attach_energy_policy"):
+            child.attach_energy_policy(self.energy_policy)
 
         if getattr(parent, "role", None) == "emitter":
             cap = getattr(parent, "emitter_split_cap", None)
@@ -2362,8 +2373,9 @@ class CogGraph:
             return torch.zeros(unit.input_size).unsqueeze(0)
 
     def reward_emitter_grid_environment(self):
-        decay_threshold = 40  # 超过 30 步未奖励就开始衰减
-        decay_amount = 0.04  # 每步扣能量
+        policy = self.energy_policy
+        decay_threshold = policy.inactivity_threshold()
+        decay_amount = policy.inactivity_decay()
         """基于 emitter 输出，在网格环境中执行资源 / 陷阱 奖励与惩罚逻辑。"""
         outputs = self.collect_emitter_outputs()
         if outputs is None:
@@ -2377,8 +2389,10 @@ class CogGraph:
             pred = torch.argmax(self._align_to_goal_dim(out)).item()
             px, py = pred % self.env_size, pred // self.env_size
             if (px, py) == unit.personal_goal:
-                unit.energy += unit.intrinsic_reward
-                unit.meta.record(action="intrinsic", reward=+unit.intrinsic_reward)
+                intrinsic_bonus = policy.intrinsic_completion_bonus()
+                unit.intrinsic_reward = intrinsic_bonus
+                unit.energy += intrinsic_bonus
+                unit.meta.record(action="intrinsic", reward=+intrinsic_bonus)
                 logger.info("你达到了你好奇的地方，心中充满了决心")
                 unit.visit_counts.setdefault((px, py), 0)
                 unit.visit_counts[(px, py)] += 1
@@ -2447,11 +2461,13 @@ class CogGraph:
                     logger.info(f"[目标切换] emitter {unit.id} 接近陷阱后撤退，发现不对劲，有歹徒要害我！ → 切换为好奇点 {unit.personal_goal}")
 
             if is_hz_hit and (hx, hy) in self.env.hazards:
-                unit.energy -= 0.50
-                unit.meta.record(action=pred_idx, reward=-0.5)
+                hazard_loss, hazard_share = policy.hazard_penalties()
+                unit.energy -= hazard_loss
+                unit.meta.record(action=pred_idx, reward=-hazard_loss)
                 for p in upstream_processors:
-                    p.energy -= 0.4
-                    p.meta.record(action=pred_idx, reward=-0.125)
+                    if hazard_share > 0.0:
+                        p.energy -= hazard_share
+                        p.meta.record(action=pred_idx, reward=-hazard_share)
                 unit.is_hazard_confirmed = True
                 unit.last_action_rewarded = False
                 if self.env.hazards[(hx, hy)] > 0:
@@ -2484,8 +2500,10 @@ class CogGraph:
                 hz_dist = math.hypot(px - hx, py - hy)
 
             if unit.is_hazard_confirmed and hz_dist > 3.0:
-                unit.energy += 0.04
-                unit.meta.record(action=pred_idx, reward=+0.04)
+                escape_bonus = policy.hazard_escape_bonus()
+                if escape_bonus > 0.0:
+                    unit.energy += escape_bonus
+                    unit.meta.record(action=pred_idx, reward=+escape_bonus)
                 unit.is_hazard_confirmed = False
                 unit.last_reward_step = self.current_step
                 unit.last_action_rewarded = True
@@ -2495,16 +2513,21 @@ class CogGraph:
                 continue
 
             if (unit.last_rewarded_target_idx != cur_idx) and (is_res_hit or is_res_near):
-                base_r = max(0.02 * (1.0 - res_dist), 0.0)
-                unit.energy += base_r
-                unit.meta.record(action=cur_idx, reward=+base_r)
-                for p in upstream_processors:
-                    p.energy += base_r * 0.25
-                    p.meta.record(action=cur_idx, reward=+(base_r * 0.25))
+                base_r = policy.resource_base_reward(res_dist)
+                share_ratio = policy.resource_upstream_share()
+                if base_r > 0.0:
+                    unit.energy += base_r
+                    unit.meta.record(action=cur_idx, reward=+base_r)
+                    for p in upstream_processors:
+                        share = base_r * share_ratio
+                        if share > 0.0:
+                            p.energy += share
+                            p.meta.record(action=cur_idx, reward=+share)
 
                 if is_res_hit:
-                    unit.energy += 1.2
-                    unit.meta.record(action=cur_idx, reward=+1.2)
+                    hit_bonus = policy.resource_hit_bonus()
+                    unit.energy += hit_bonus
+                    unit.meta.record(action=cur_idx, reward=+hit_bonus)
                     if self.env.resources[(x_res, y_res)] > 0:
                         self.env.resources[(x_res, y_res)] -= 1
                         if self.env.resources[(x_res, y_res)] == 0:
@@ -2521,6 +2544,11 @@ class CogGraph:
                         del self.env.hazards[far]
                         self.env.update_known_cell(far)
                         self.removed_hazards_by_reward += 1
+                    for p in upstream_processors:
+                        share = hit_bonus * share_ratio
+                        if share > 0.0:
+                            p.energy += share
+                            p.meta.record(action=cur_idx, reward=+share)
                     if getattr(unit, "is_permanent_explorer", False):
                         continue  # 永久探索者不应被重设为资源目标
 
@@ -2539,9 +2567,6 @@ class CogGraph:
                     unit.last_rewarded_target_idx = None
                     unit.linger_steps = 0
                     unit.last_reward_amount = 0.0
-                    for p in upstream_processors:
-                        p.energy += 0.9
-                        p.meta.record(action="cur_idx", reward=+0.9)
 
                 unit.last_rewarded_target_idx = cur_idx
                 unit.last_reward_amount = base_r
@@ -2553,8 +2578,10 @@ class CogGraph:
             if (unit.last_rewarded_target_idx == cur_idx) and res_dist <= 2.0 and self.current_step >= 1500:
                 unit.linger_steps = min(unit.linger_steps + 1, 20)
                 if unit.linger_steps > 3:
-                    unit.energy -= 0.01
-                    unit.meta.record(action=cur_idx, reward=-0.01)
+                    linger_penalty = policy.linger_penalty()
+                    if linger_penalty > 0.0:
+                        unit.energy -= linger_penalty
+                        unit.meta.record(action=cur_idx, reward=-linger_penalty)
                 continue
 
             if (unit.last_rewarded_target_idx == cur_idx) and res_dist > 4.0:
@@ -2567,17 +2594,21 @@ class CogGraph:
             if len(action_indices) >= 3:
                 most_common = max(set(action_indices), key=action_indices.count)
                 if action_indices.count(most_common) > len(action_indices) * 0.9:
-                    unit.energy -= 0.05
-                    unit.meta.record(action="diversity_penalty", reward=-0.05)
+                    penalty = policy.diversity_penalty()
+                    if penalty > 0.0:
+                        unit.energy -= penalty
+                        unit.meta.record(action="diversity_penalty", reward=-penalty)
                 elif len(set(action_indices)) > len(action_indices) * 0.6:
-                    unit.energy += 0.05
-                    unit.meta.record(action="diversity_penalty", reward=+0.05)
+                    bonus = policy.diversity_bonus()
+                    if bonus > 0.0:
+                        unit.energy += bonus
+                        unit.meta.record(action="diversity_penalty", reward=+bonus)
 
             if self.current_step > 1500:
                 inactive_steps = self.current_step - unit.last_reward_step
                 if inactive_steps > decay_threshold:
-                    unit.energy -= decay_amount * 0.1
-                    unit.meta.record(action="round", reward=-(decay_amount * 0.1))
+                    unit.energy -= decay_amount
+                    unit.meta.record(action="round", reward=-decay_amount)
 
                 if (hasattr(unit, "output_positions")
                         and len(unit.output_positions) >= 10
@@ -2585,15 +2616,10 @@ class CogGraph:
                     start = unit.output_positions[0]
                     end = unit.output_positions[-1]
                     manhattan = abs(start[0] - end[0]) + abs(start[1] - end[1])
-                    if 3 <= manhattan < 5:
-                        unit.energy -= 0.08
-                        unit.meta.record(action="move less", reward=-0.08)
-                    elif 6 <= manhattan < 8:
-                        unit.energy -= 0.10
-                        unit.meta.record(action="move less", reward=-0.1)
-                    elif 9 <= manhattan <= 10:
-                        unit.energy -= 0.12
-                        unit.meta.record(action="move less", reward=-0.12)
+                    penalty = policy.movement_penalty(manhattan)
+                    if penalty > 0.0:
+                        unit.energy -= penalty
+                        unit.meta.record(action="move less", reward=-penalty)
 
 
     def _expand_environment_curriculum(self):

--- a/energy_policy.py
+++ b/energy_policy.py
@@ -1,0 +1,147 @@
+"""Utility classes describing the global energy economy."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+
+@dataclass
+class EnergyConfig:
+    """Configurable coefficients that shape the energy economy."""
+
+    warmup_steps: int = 200
+    warmup_increment: float = 0.01
+    high_freq_call_threshold: float = 3.5
+    high_freq_bonus: float = 0.02
+    self_reward_scale: float = 0.015
+    intrinsic_goal_bonus: float = 0.3
+    hazard_penalty: float = 0.45
+    hazard_processor_penalty: float = 0.2
+    hazard_escape_bonus: float = 0.03
+    resource_base_scale: float = 0.12
+    resource_hit_bonus: float = 0.6
+    resource_upstream_share: float = 0.2
+    linger_penalty: float = 0.008
+    monotony_penalty: float = 0.03
+    monotony_bonus: float = 0.03
+    inactivity_threshold: int = 35
+    inactivity_decay: float = 0.004
+    diversity_penalty: float = 0.03
+    diversity_bonus: float = 0.03
+    movement_penalties: Tuple[Tuple[int, int, float], ...] = (
+        (3, 5, 0.06),
+        (6, 8, 0.08),
+        (9, 11, 0.1),
+    )
+    pool_primary_cap: float = 0.2
+    pool_secondary_cap: float = 0.08
+    pool_stability_factor: float = 0.04
+
+
+class EnergyPolicy:
+    """Helper that converts behavioural statistics into energy deltas."""
+
+    def __init__(self, config: EnergyConfig | None = None) -> None:
+        self.config = config or EnergyConfig()
+
+    # ----- warmup / upkeep -------------------------------------------------
+    def warmup_bonus(self, step: int) -> float:
+        if step < self.config.warmup_steps:
+            return self.config.warmup_increment
+        return 0.0
+
+    # ----- intrinsic & local adjustments -----------------------------------
+    def high_frequency_bonus(self, avg_calls: float) -> float:
+        if avg_calls >= self.config.high_freq_call_threshold:
+            return self.config.high_freq_bonus
+        return 0.0
+
+    def scale_self_reward(self, reward_signal: float) -> float:
+        if reward_signal <= 0.0:
+            return 0.0
+        return reward_signal * self.config.self_reward_scale
+
+    def intrinsic_completion_bonus(self) -> float:
+        return self.config.intrinsic_goal_bonus
+
+    # ----- hazards ---------------------------------------------------------
+    def hazard_penalties(self) -> Tuple[float, float]:
+        return (self.config.hazard_penalty, self.config.hazard_processor_penalty)
+
+    def hazard_escape_bonus(self) -> float:
+        return self.config.hazard_escape_bonus
+
+    # ----- resources -------------------------------------------------------
+    def resource_base_reward(self, proximity: float) -> float:
+        closeness = max(1.0 - proximity, 0.0)
+        return max(closeness * self.config.resource_base_scale, 0.0)
+
+    def resource_hit_bonus(self) -> float:
+        return self.config.resource_hit_bonus
+
+    def resource_upstream_share(self) -> float:
+        return self.config.resource_upstream_share
+
+    # ----- behavioural penalties ------------------------------------------
+    def linger_penalty(self) -> float:
+        return self.config.linger_penalty
+
+    def monotony_penalty(self) -> float:
+        return self.config.monotony_penalty
+
+    def monotony_bonus(self) -> float:
+        return self.config.monotony_bonus
+
+    def diversity_penalty(self) -> float:
+        return self.config.diversity_penalty
+
+    def diversity_bonus(self) -> float:
+        return self.config.diversity_bonus
+
+    def inactivity_threshold(self) -> int:
+        return self.config.inactivity_threshold
+
+    def inactivity_decay(self) -> float:
+        return self.config.inactivity_decay
+
+    def movement_penalty(self, manhattan: int) -> float:
+        for low, high, penalty in self.config.movement_penalties:
+            if low <= manhattan < high:
+                return penalty
+        return 0.0
+
+    # ----- pool distribution -----------------------------------------------
+    def pool_caps(self) -> Tuple[float, float]:
+        return (self.config.pool_primary_cap, self.config.pool_secondary_cap)
+
+    def pool_stability_factor(self) -> float:
+        return self.config.pool_stability_factor
+
+    # ----- helpers ---------------------------------------------------------
+    def describe(self) -> dict:
+        """Return a serialisable snapshot for debugging/telemetry."""
+        return {
+            "warmup_steps": self.config.warmup_steps,
+            "warmup_increment": self.config.warmup_increment,
+            "high_freq_call_threshold": self.config.high_freq_call_threshold,
+            "high_freq_bonus": self.config.high_freq_bonus,
+            "self_reward_scale": self.config.self_reward_scale,
+            "intrinsic_goal_bonus": self.config.intrinsic_goal_bonus,
+            "hazard_penalty": self.config.hazard_penalty,
+            "hazard_processor_penalty": self.config.hazard_processor_penalty,
+            "hazard_escape_bonus": self.config.hazard_escape_bonus,
+            "resource_base_scale": self.config.resource_base_scale,
+            "resource_hit_bonus": self.config.resource_hit_bonus,
+            "resource_upstream_share": self.config.resource_upstream_share,
+            "linger_penalty": self.config.linger_penalty,
+            "monotony_penalty": self.config.monotony_penalty,
+            "monotony_bonus": self.config.monotony_bonus,
+            "inactivity_threshold": self.config.inactivity_threshold,
+            "inactivity_decay": self.config.inactivity_decay,
+            "diversity_penalty": self.config.diversity_penalty,
+            "diversity_bonus": self.config.diversity_bonus,
+            "movement_penalties": list(self.config.movement_penalties),
+            "pool_primary_cap": self.config.pool_primary_cap,
+            "pool_secondary_cap": self.config.pool_secondary_cap,
+            "pool_stability_factor": self.config.pool_stability_factor,
+        }


### PR DESCRIPTION
## Summary
- add an `EnergyPolicy` helper to centralise coefficients for the organism energy economy
- hook CogUnit and CogGraph mechanics to the shared policy so warmup, pooling and rewards use consistent scaling
- retune emitter hazard/resource gains plus self-reward bonuses to keep net metabolism balanced

## Testing
- python -m compileall energy_policy.py CogUnit.py coggraph.py

------
https://chatgpt.com/codex/tasks/task_e_68e6c3eb033c8322bf63c2d1679b37d1