### PR TITLE
Fix environment truncation and subgraph restructuring crash

### DIFF
--- a/coggraph.py
+++ b/coggraph.py
@@ -743,9 +743,11 @@ class CogGraph:
         candidates = [(self.unit_map[p], self.unit_map[e]) for ((p, e), _) in calls[:topk]
                       if p in self.unit_map and e in self.unit_map]
 
+        limit = len(candidates)
+
         # 再在这 top-K 里两重比较
-        for i in range(len(candidates)):
-            for j in range(i + 1, topk):
+        for i in range(limit):
+            for j in range(i + 1, limit):
 
                 p1, e1 = candidates[i]
                 p2, e2 = candidates[j]

--- a/env.py
+++ b/env.py
@@ -276,6 +276,10 @@ class GridEnvironment:
         if self.resources[pos] > 0:
             self.reward_hit_count += 1
             self.agent_energy_gain = 0.1
+            self.resources[pos] -= 1
+            if self.resources[pos] <= 0:
+                self.resources.pop(pos, None)
+            self.update_known_cell(pos)
         else:
             self.agent_energy_gain = 0.0
 
@@ -283,6 +287,7 @@ class GridEnvironment:
         if self.hazards[pos] > 0:
             self.danger_hit_count += 1
             self.agent_energy_penalty = 0.1
+            self.update_known_cell(pos)
         else:
             self.agent_energy_penalty = 0.0
 
@@ -327,7 +332,11 @@ class GridEnvironment:
 
         done = False
         if not self.resources:
-            done = True
+            if self._chunk_index < len(self._resource_chunk_plan) or \
+               self._chunk_index < len(self._hazard_chunk_plan):
+                self._distribute_chunk(exclude_positions={tuple(self.agent_pos)})
+            if not self.resources:
+                done = True
         elif self.max_steps is not None and self.step_count >= self.max_steps:
             done = True
 


### PR DESCRIPTION
## Summary
- ensure resource pickups deplete counters, refresh known cell state, and request the next spawn chunk before ending a horizon
- update hazard handling to refresh sensor knowledge when stepped on
- guard the common subgraph restructuring loop against out-of-range access when fewer than top-k candidates exist

## Testing
- python -m compileall env.py coggraph.py

------
https://chatgpt.com/codex/tasks/task_e_68e733002f608322805907f83678e2ab