### PR TITLE
Enhance processor support to maintain 1:2:1 role ratio

### DIFF
--- a/coggraph.py
+++ b/coggraph.py
@@ -1063,6 +1063,9 @@ class CogGraph:
         else:
             hi, lo = 1.05, 0.95
 
+        hi_map = {"sensor": hi, "emitter": hi, "processor": hi + 0.04}
+        lo_map = {"sensor": lo, "emitter": lo, "processor": min(lo + 0.05, 0.98)}
+
         # Δ 容差（至少相差 Δ_cell 才算“真的多／少”）
         delta_cell = max(1, int(total * TOL_FRAC))
 
@@ -1114,8 +1117,15 @@ class CogGraph:
             }
 
             # 1) 满足 ratio>hi 且 diff≥Δ 才算“over”   2) ratio<lo 且 diff≤-Δ 算“under”
-            overs = [r for r in ratio if ratio[r] > hi and diff[r] >= delta_cell]
-            unders = [r for r in ratio if ratio[r] < lo and diff[r] <= -delta_cell]
+            overs = [r for r in ratio if ratio[r] > hi_map[r] and diff[r] >= delta_cell]
+            unders = [r for r in ratio if ratio[r] < lo_map[r] and diff[r] <= -delta_cell]
+
+            # processor 长期短缺时，允许从最富余的角色借位
+            if "processor" in unders and not overs:
+                fallback = [r for r in ("sensor", "emitter") if diff[r] > 0]
+                if not fallback:
+                    fallback = [max(ratio, key=ratio.get)] if ratio else []
+                overs = fallback
 
             if not overs or not unders:
                 break  # 落入迟滞带 or Δ 太小，结束
@@ -1134,7 +1144,10 @@ class CogGraph:
             old = unit.get_role()
             unit.role = receiver_role
             unit.age = 0
-            unit.energy += 0
+            if receiver_role == "processor":
+                unit.energy = max(unit.energy, 0.95)
+            else:
+                unit.energy += 0
             unit.gene[f"{receiver_role}_bias"] = 1.0
             logger.info(f"[平衡] {old}→{receiver_role} | step={self.current_step}")
 
@@ -1566,7 +1579,22 @@ class CogGraph:
         growth = 0.16 * math.sqrt(bias)
         ceiling = 1.18 if unit.role == "processor" else 1.08
         floor = 0.58 if unit.role == "processor" else 0.52
-        return max(floor, min(ceiling, base + growth))
+
+        if unit.role == "processor":
+            total = max(1, len(self.units))
+            ideal_proc = total * IDEAL_RATIO["processor"] / DENOM
+            current_proc = max(0, self.processor_count)
+            shortage = max(0.0, ideal_proc - current_proc)
+            if ideal_proc > 0.0 and shortage > 0.0:
+                shortage_ratio = min(1.0, shortage / ideal_proc)
+                boost = 1.0 + 0.35 * shortage_ratio
+                base *= boost
+                growth *= 1.0 + 0.45 * shortage_ratio
+                floor += 0.12 * shortage_ratio
+                ceiling = min(1.45, ceiling + 0.22 * shortage_ratio)
+
+        target = base + growth
+        return max(floor, min(ceiling, target))
 
     def _emitter_priority_score(self, unit: CogUnit) -> float:
         recent = getattr(unit, "avg_recent_calls", 0.0)

--- a/energy_policy.py
+++ b/energy_policy.py
@@ -46,6 +46,8 @@ class EnergyPolicy:
         self._resource_share = self.config.resource_upstream_share
         self._hazard_escape = self.config.hazard_escape_bonus
         self._success_ratio = 0.5
+        # Processor:Emitter 理想目标 = 2:1，记录当前偏差用于能量调整
+        self._processor_balance = 1.0
 
     # ----- warmup / upkeep -------------------------------------------------
     def warmup_bonus(self, step: int) -> float:
@@ -72,6 +74,12 @@ class EnergyPolicy:
         success = float(max(0.0, min(1.0, self._success_ratio)))
         primary = self.config.hazard_penalty * (0.85 + 0.3 * success)
         secondary = self.config.hazard_processor_penalty * (0.75 + 0.4 * success)
+
+        # 若 processor 短缺，则降低其额外惩罚，避免雪上加霜
+        shortage = max(0.0, 1.0 - float(self._processor_balance))
+        if shortage > 0.0:
+            secondary *= 1.0 - min(0.45, 0.35 + 0.35 * shortage)
+            secondary = max(0.05, secondary)
         return (primary, secondary)
 
     def hazard_escape_bonus(self) -> float:
@@ -107,12 +115,16 @@ class EnergyPolicy:
         danger_pressure = 1.0 - self._success_ratio
         base_share = self.config.resource_upstream_share * (1.0 + 0.25 * danger_pressure)
 
+        target_balance = 2.0  # processor : emitter = 2 : 1
         balance = processor_count / max(1, emitter_count)
-        balance = float(max(0.2, min(balance, 3.0)))
-        if balance < 1.0:
-            base_share *= 1.0 + (1.0 - balance) * 0.35
+        normalized = balance / target_balance if target_balance > 0 else 1.0
+        normalized = float(max(0.2, min(normalized, 3.0)))
+        if normalized < 1.0:
+            base_share *= 1.0 + (1.0 - normalized) * 0.55
         else:
-            base_share *= 1.0 - min(balance - 1.0, 1.5) * 0.2
+            base_share *= 1.0 - min(normalized - 1.0, 1.5) * 0.25
+
+        self._processor_balance = normalized
 
         if exploration_ratio is not None:
             ratio = float(max(0.0, min(1.0, exploration_ratio)))
@@ -175,6 +187,7 @@ class EnergyPolicy:
             "resource_hit_bonus": self.config.resource_hit_bonus,
             "resource_upstream_share": self.config.resource_upstream_share,
             "dynamic_resource_share": self._resource_share,
+            "processor_balance_factor": self._processor_balance,
             "dynamic_hazard_escape_bonus": self._hazard_escape,
             "dynamic_success_ratio": self._success_ratio,
             "linger_penalty": self.config.linger_penalty,


### PR DESCRIPTION
## Summary
- tune the energy policy to treat the processor:emitter goal as 2:1, softening processor hazard penalties when they are scarce
- bias rebalance logic toward keeping processors plentiful and give converted units a starter energy buffer
- raise processor energy targets dynamically when they fall short of the ideal share

## Testing
- python -m compileall energy_policy.py coggraph.py

------
https://chatgpt.com/codex/tasks/task_e_68e8681eb40083228a08b5628fce0bb5