### PR TITLE
Recalculate cell-density scaling during chunk drops

### DIFF
--- a/coggraph.py
+++ b/coggraph.py
@@ -368,6 +368,8 @@ class CogGraph:
             u.global_processor_count = self.processor_count
             u.global_emitter_count   = self.emitter_count
             u.global_unit_count      = total
+        if hasattr(self, "env") and hasattr(self.env, "update_cell_population"):
+            self.env.update_cell_population(total)
 
     def _log_stats_and_conns(self):
         """集中打印一次统计 & 连接强度，避免散落在内层循环里重复计算"""

--- a/env.py
+++ b/env.py
@@ -50,9 +50,15 @@ class GridEnvironment:
         self.refresh_cycle_steps = 1000
         self.refresh_chunk_steps = 200
         self._cycle_anchor_step = 0
-        self._resource_chunk_plan: list[int] = []
-        self._hazard_chunk_plan: list[int] = []
+        self._chunks_per_cycle = max(
+            1,
+            self.refresh_cycle_steps // self.refresh_chunk_steps
+            if self.refresh_chunk_steps > 0
+            else 1,
+        )
         self._chunk_index = 0
+        self._resource_base_target = 0.0
+        self._hazard_base_target = 0.0
 
         # 经验点和危险点
         self.resources = Counter()
@@ -62,6 +68,13 @@ class GridEnvironment:
         self.step_count = 0
         self.explored_cells_count = 0
         self.agent_pos = [random.randrange(self.size), random.randrange(self.size)]
+
+        # 细胞密度自适应调节
+        self._cell_count = 0
+        self._cell_density = 0.0
+        self._cell_density_baseline: float | None = None
+        self._cell_adjust_resource = 1.0
+        self._cell_adjust_hazard = 1.0
 
         # 记忆保留 & 反馈追踪
         self.reward_hit_count = 0
@@ -193,16 +206,54 @@ class GridEnvironment:
             counter.pop(pos, None)
             self.update_known_cell(pos)
 
+    def _compute_cell_density_adjustments(self) -> tuple[float, float]:
+        resource_multiplier = 1.0
+        hazard_multiplier = 1.0
+        baseline = self._cell_density_baseline
+        density = self._cell_density
+        if baseline is not None and baseline > 1e-6:
+            relative_delta = (density - baseline) / max(baseline, 1e-6)
+            relative_delta = max(-0.6, min(0.6, relative_delta))
+            adjust_strength = 0.5
+            resource_multiplier = 1.0 - adjust_strength * relative_delta
+            hazard_multiplier = 1.0 + adjust_strength * relative_delta
+            resource_multiplier = max(0.7, min(1.3, resource_multiplier))
+            hazard_multiplier = max(0.7, min(1.3, hazard_multiplier))
+        self._cell_adjust_resource = resource_multiplier
+        self._cell_adjust_hazard = hazard_multiplier
+        return resource_multiplier, hazard_multiplier
+
     def _distribute_chunk(self, exclude_positions: set | None = None):
-        if self._chunk_index >= len(self._resource_chunk_plan):
+        if self.refresh_chunk_steps <= 0:
+            return
+
+        if self._chunk_index >= self._chunks_per_cycle:
             return
 
         exclude_positions = set(exclude_positions or set())
         exclude_positions.add(tuple(self.agent_pos))
 
+        resource_multiplier, hazard_multiplier = self._compute_cell_density_adjustments()
+        adjusted_resource_target = int(round(self._resource_base_target * resource_multiplier))
+        adjusted_hazard_target = int(round(self._hazard_base_target * hazard_multiplier))
+
+        self._trim_points(self.resources, max(0, len(self.resources) - adjusted_resource_target))
+        self._trim_points(self.hazards, max(0, len(self.hazards) - adjusted_hazard_target))
+
+        remaining_chunks = max(1, self._chunks_per_cycle - self._chunk_index)
+
+        needed_resources = max(0, adjusted_resource_target - len(self.resources))
+        needed_hazards = max(0, adjusted_hazard_target - len(self.hazards))
+
+        base_res, rem_res = divmod(needed_resources, remaining_chunks)
+        base_haz, rem_haz = divmod(needed_hazards, remaining_chunks)
+
+        resources_to_spawn = base_res + (1 if rem_res > 0 else 0)
+        hazards_to_spawn = base_haz + (1 if rem_haz > 0 else 0)
+
         resource_blocked = exclude_positions | set(self.resources.keys())
         new_resources = self._sample_weighted_positions(
-            self._resource_chunk_plan[self._chunk_index],
+            resources_to_spawn,
             blocked=resource_blocked,
             frontier_weight=1.6,
             revisit_weight=1.0,
@@ -212,7 +263,7 @@ class GridEnvironment:
 
         hazard_blocked = exclude_positions | set(self.hazards.keys())
         new_hazards = self._sample_weighted_positions(
-            self._hazard_chunk_plan[self._chunk_index],
+            hazards_to_spawn,
             blocked=hazard_blocked,
             frontier_weight=2.2,
             revisit_weight=0.8,
@@ -251,8 +302,8 @@ class GridEnvironment:
         extra = min(80, max(((self.step_count - 1200) // 300), 0))
         base_resource_density = 0.18
         growth_factor = 0.75 + 0.45 * explored_ratio
-        resource_target = int(area * base_resource_density * growth_factor)
-        resource_target += int(extra * (0.5 + 0.5 * success_ratio))
+        resource_target_base = area * base_resource_density * growth_factor
+        resource_target_base += extra * (0.5 + 0.5 * success_ratio)
 
         base_hazard_density = 0.22
         hazard_adjust = 1.0 - 0.6 * (0.5 - success_ratio)
@@ -260,17 +311,28 @@ class GridEnvironment:
         caution_factor = 0.9 + 0.2 * (1.0 - explored_ratio)
         hazard_density = base_hazard_density * hazard_adjust * caution_factor
         hazard_density = max(0.14, min(0.28, hazard_density))
-        hazard_target = int(area * hazard_density)
-        hazard_target += int(extra * (0.6 + 0.4 * (1.0 - success_ratio)))
+        hazard_target_base = area * hazard_density
+        hazard_target_base += extra * (0.6 + 0.4 * (1.0 - success_ratio))
+
+        resource_multiplier, hazard_multiplier = self._compute_cell_density_adjustments()
+
+        resource_target = int(round(resource_target_base * resource_multiplier))
+        hazard_target = int(round(hazard_target_base * hazard_multiplier))
+        resource_target = max(0, resource_target)
+        hazard_target = max(0, hazard_target)
+
+        self._resource_base_target = max(0.0, resource_target_base)
+        self._hazard_base_target = max(0.0, hazard_target_base)
 
         self._trim_points(self.resources, max(0, len(self.resources) - resource_target))
         self._trim_points(self.hazards, max(0, len(self.hazards) - hazard_target))
 
-        to_add_res = max(0, resource_target - len(self.resources))
-        to_add_haz = max(0, hazard_target - len(self.hazards))
-
-        self._resource_chunk_plan = self._build_chunk_plan(to_add_res)
-        self._hazard_chunk_plan = self._build_chunk_plan(to_add_haz)
+        self._chunks_per_cycle = max(
+            1,
+            self.refresh_cycle_steps // self.refresh_chunk_steps
+            if self.refresh_chunk_steps > 0
+            else 1,
+        )
         self._chunk_index = 0
         self._cycle_anchor_step = step
 
@@ -279,6 +341,18 @@ class GridEnvironment:
         self._distribute_chunk(exclude_positions=exclude_positions)
         self.prev_dist_resource = self.distance_to_nearest_known_resource(tuple(self.agent_pos))
         self.prev_danger_dist = self.distance_to_nearest_known_danger(tuple(self.agent_pos))
+
+    def update_cell_population(self, cell_count: int) -> None:
+        """更新细胞数量统计，用于在刷新时调整资源/危险比例。"""
+        self._cell_count = max(0, int(cell_count))
+        area = max(1, self.size * self.size)
+        density = self._cell_count / area
+        self._cell_density = density
+        if self._cell_density_baseline is None:
+            self._cell_density_baseline = density
+        else:
+            alpha = 0.12
+            self._cell_density_baseline = (1.0 - alpha) * self._cell_density_baseline + alpha * density
 
     def _in_bounds(self, x: int, y: int) -> bool:
         return 0 <= x < self.size and 0 <= y < self.size
@@ -477,8 +551,7 @@ class GridEnvironment:
         elif refresh_triggered and self.refresh_cycle_steps > 0:
             done = True
         elif not self.resources:
-            if self._chunk_index < len(self._resource_chunk_plan) or \
-               self._chunk_index < len(self._hazard_chunk_plan):
+            if self.refresh_chunk_steps > 0 and self._chunk_index < self._chunks_per_cycle:
                 self._distribute_chunk(exclude_positions={tuple(self.agent_pos)})
 
         return next_state, reward, done, {}
@@ -530,6 +603,7 @@ class GridEnvironment:
     def resize(self, new_size: int):
         self.size = new_size
         self._init_buffers()
+        self._cell_density_baseline = None
 
         x, y = self.agent_pos
         x = min(x, new_size - 1)
@@ -547,6 +621,7 @@ class GridEnvironment:
         self.explored_cells_count = 0
         self.reward_hit_count = 0
         self.danger_hit_count = 0
+        self._cell_density_baseline = None
         self.refresh_environment(step=0, explored_cells_count=0, exclude_positions={tuple(self.agent_pos)})
 
     def inject_reward_map(self, reward_points: list[tuple[int,int]], punishment_points: list[tuple[int,int]]):


### PR DESCRIPTION
## Summary
- recompute the cell-density multipliers whenever a chunk distribution runs so each 200-step drop reacts to the latest population ratios
- replace the fixed chunk plan bookkeeping with dynamic targets derived from the stored base totals to keep trimming and additions aligned with the refreshed multipliers
- update the empty-map refill path to respect the new chunk scheduling metadata

## Testing
- python -m compileall env.py coggraph.py

------
https://chatgpt.com/codex/tasks/task_e_68e87b13b0348322bdf8e56ea5bf3f1e